### PR TITLE
feat: dispute resolution voting UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from "react-router-dom";
 import DashboardLayout from "./components/Dashboard/DashboardLayout";
 import SettlementProposalForm from "./components/SettlementProposal/SettlementProposalForm";
+import DisputeVotingPanel from "./components/DisputeVoting/DisputeVotingPanel";
 
 function InvoicesPage() {
   return <p>Invoices list will appear here.</p>;
@@ -11,7 +12,7 @@ function SettlementsPage() {
 }
 
 function DisputesPage() {
-  return <p>Disputes list will appear here.</p>;
+  return <DisputeVotingPanel />;
 }
 
 function SettingsPage() {

--- a/frontend/src/components/DisputeVoting/DisputeVotingPanel.css
+++ b/frontend/src/components/DisputeVoting/DisputeVotingPanel.css
@@ -1,0 +1,155 @@
+.dispute-panel {
+  max-width: 720px;
+}
+
+.dispute-panel__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 24px;
+  color: var(--color-text);
+}
+
+.dispute-panel__section-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  margin-bottom: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.dispute-panel__error {
+  color: var(--color-danger);
+}
+
+.dispute-card {
+  background: var(--color-card-bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 20px 24px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.dispute-card__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.dispute-card__id {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--color-text);
+}
+
+.dispute-card__section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dispute-card__label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.dispute-card__votes {
+  display: flex;
+  gap: 32px;
+}
+
+.dispute-card__vote-col {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dispute-card__actions {
+  display: flex;
+  gap: 10px;
+}
+
+.dispute-card__voted {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.dispute-card__error {
+  font-size: 0.85rem;
+  color: var(--color-danger);
+}
+
+.vote-btn {
+  padding: 8px 16px;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.vote-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.vote-btn--claimant {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.vote-btn--counterparty {
+  background: var(--color-danger);
+  color: #fff;
+}
+
+.outcome-badge {
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.outcome-badge--claimant {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.outcome-badge--counterparty {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.resolution-bar-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.resolution-bar {
+  width: 120px;
+  height: 8px;
+  background: #e5e7eb;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.resolution-bar__fill {
+  height: 100%;
+  background: var(--color-primary);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.resolution-bar__label {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}

--- a/frontend/src/components/DisputeVoting/DisputeVotingPanel.tsx
+++ b/frontend/src/components/DisputeVoting/DisputeVotingPanel.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react'
+import { Dispute, DisputeOutcome } from '../../types/dispute'
+import { useDisputes } from '../../hooks/useDisputes'
+import './DisputeVotingPanel.css'
+
+const CURRENT_SIGNER = import.meta.env.VITE_SIGNER_1 ?? ''
+
+function shorten(addr: string): string {
+  if (!addr || addr.length < 12) return addr
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`
+}
+
+function OutcomeBadge({ outcome }: { outcome: DisputeOutcome }) {
+  return (
+    <span className={`outcome-badge outcome-badge--${outcome === 'ResolvedClaimant' ? 'claimant' : 'counterparty'}`}>
+      {outcome === 'ResolvedClaimant' ? 'Resolved: Claimant' : 'Resolved: Counterparty'}
+    </span>
+  )
+}
+
+function ResolutionBar({ current, threshold }: { current: number; threshold: number }) {
+  const pct = Math.min(100, Math.round((current / threshold) * 100))
+  return (
+    <div className="resolution-bar-wrap">
+      <div className="resolution-bar">
+        <div className="resolution-bar__fill" style={{ width: `${pct}%` }} />
+      </div>
+      <span className="resolution-bar__label">{current} / {threshold}</span>
+    </div>
+  )
+}
+
+function DisputeCard({ dispute, onVote }: { dispute: Dispute; onVote: (id: number, v: DisputeOutcome) => Promise<void> }) {
+  const [voting, setVoting] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const hasVoted = dispute.votes.some(v => v.signer === CURRENT_SIGNER)
+  const resolved = dispute.outcome !== null
+
+  const handleVote = async (vote: DisputeOutcome) => {
+    setVoting(true)
+    setErr(null)
+    try {
+      await onVote(dispute.settlement_id, vote)
+    } catch (e: any) {
+      setErr(e.message)
+    } finally {
+      setVoting(false)
+    }
+  }
+
+  return (
+    <div className="dispute-card">
+      <div className="dispute-card__header">
+        <span className="dispute-card__id">Settlement #{dispute.settlement_id}</span>
+        {resolved && <OutcomeBadge outcome={dispute.outcome!} />}
+      </div>
+
+      <div className="dispute-card__section">
+        <span className="dispute-card__label">Resolution weight</span>
+        <ResolutionBar current={dispute.resolution_weight} threshold={dispute.threshold} />
+      </div>
+
+      <div className="dispute-card__votes">
+        <div className="dispute-card__vote-col">
+          <span className="dispute-card__label">Claimant ({dispute.claimant_weight})</span>
+        </div>
+        <div className="dispute-card__vote-col">
+          <span className="dispute-card__label">Counterparty ({dispute.counterparty_weight})</span>
+        </div>
+      </div>
+
+      {!resolved && (
+        <div className="dispute-card__actions">
+          <button
+            className="vote-btn vote-btn--claimant"
+            disabled={hasVoted || voting}
+            onClick={() => handleVote('ResolvedClaimant')}
+          >
+            Vote Claimant
+          </button>
+          <button
+            className="vote-btn vote-btn--counterparty"
+            disabled={hasVoted || voting}
+            onClick={() => handleVote('ResolvedCounterparty')}
+          >
+            Vote Counterparty
+          </button>
+        </div>
+      )}
+
+      {hasVoted && !resolved && <p className="dispute-card__voted">You have voted.</p>}
+      {err && <p className="dispute-card__error">{err}</p>}
+    </div>
+  )
+}
+
+export default function DisputeVotingPanel() {
+  const { disputes, loading, error, voteDispute } = useDisputes()
+
+  if (loading && disputes.length === 0) return <div className="dispute-panel"><p>Loading disputes...</p></div>
+  if (error && disputes.length === 0) return <div className="dispute-panel"><p className="dispute-panel__error">Error: {error}</p></div>
+
+  const open = disputes.filter(d => d.outcome === null)
+  const resolved = disputes.filter(d => d.outcome !== null)
+
+  return (
+    <div className="dispute-panel">
+      <h2 className="dispute-panel__title">Dispute Resolution</h2>
+      {open.length === 0 && resolved.length === 0 && <p>No disputes found.</p>}
+      {open.length > 0 && (
+        <section>
+          <h3 className="dispute-panel__section-title">Open Disputes</h3>
+          {open.map(d => <DisputeCard key={d.settlement_id} dispute={d} onVote={voteDispute} />)}
+        </section>
+      )}
+      {resolved.length > 0 && (
+        <section>
+          <h3 className="dispute-panel__section-title">Resolved</h3>
+          {resolved.map(d => <DisputeCard key={d.settlement_id} dispute={d} onVote={voteDispute} />)}
+        </section>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useDisputes.ts
+++ b/frontend/src/hooks/useDisputes.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Dispute, DisputeOutcome } from '../types/dispute'
+
+const API_BASE = '/api'
+
+export function useDisputes() {
+  const [disputes, setDisputes] = useState<Dispute[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchDisputes = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const res = await fetch(`${API_BASE}/treasury/disputes`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setDisputes(await res.json())
+    } catch (e: any) {
+      setError(e.message || 'Failed to fetch disputes')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchDisputes()
+    const interval = setInterval(fetchDisputes, 15_000)
+    return () => clearInterval(interval)
+  }, [fetchDisputes])
+
+  const voteDispute = useCallback(async (settlementId: number, vote: DisputeOutcome) => {
+    const res = await fetch(`${API_BASE}/treasury/vote-dispute`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ settlement_id: settlementId, vote }),
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const updated: Dispute = await res.json()
+    setDisputes(prev => prev.map(d => d.settlement_id === settlementId ? updated : d))
+  }, [])
+
+  return { disputes, loading, error, voteDispute, refresh: fetchDisputes }
+}

--- a/frontend/src/types/dispute.ts
+++ b/frontend/src/types/dispute.ts
@@ -1,0 +1,17 @@
+export type DisputeOutcome = 'ResolvedClaimant' | 'ResolvedCounterparty'
+
+export interface DisputeVote {
+  signer: string
+  vote: DisputeOutcome
+  weight: number
+}
+
+export interface Dispute {
+  settlement_id: number
+  claimant_weight: number
+  counterparty_weight: number
+  resolution_weight: number
+  threshold: number
+  outcome: DisputeOutcome | null
+  votes: DisputeVote[]
+}


### PR DESCRIPTION
closes #29 
closes #30 


Implements DisputeVotingPanel with signer vote buttons (ResolvedClaimant / ResolvedCounterparty), resolution_weight progress bar, post-vote button disable, and outcome badge on resolution. Wired into the /disputes route.