### PR TITLE
chore: pin Rust toolchain to 1.78.0 with wasm32-unknown-unknown

### DIFF
--- a/COMEBACKHERE-contracts/rust-toolchain.toml
+++ b/COMEBACKHERE-contracts/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.78.0"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
closes #31 
Adds COMEBACKHERE-contracts/rust-toolchain.toml pinning channel to 1.78.0 and including the wasm32-unknown-unknown target for consistent builds across contributors and CI.