### PR TITLE
feat: add compliance address management UI and treasury threshold update

### DIFF
--- a/COMEBACKHERE-contracts/contracts/compliance/src/lib.rs
+++ b/COMEBACKHERE-contracts/contracts/compliance/src/lib.rs
@@ -1,20 +1,29 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol};
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ContractError {
-    Unpermitted = 1,
+    Unauthorized = 1,
     ContractPaused = 2,
+    AlreadyInitialized = 3,
+}
+
+#[contracttype]
+pub enum AddressStatus {
+    Allowed,
+    AllowedUntil(u64),
+    Blocked,
+    Cleared,
 }
 
 #[contracttype]
 pub enum DataKey {
     Admin,
     Paused,
-    Allowed(Address),
+    Status(Address),
 }
 
 #[contract]
@@ -28,22 +37,52 @@ impl ComplianceContract {
     }
 
     pub fn is_allowed(e: Env, addr: Address) -> bool {
-        e.storage().instance().get(&DataKey::Allowed(addr)).unwrap_or(false)
+        match e
+            .storage()
+            .instance()
+            .get(&DataKey::Status(addr))
+            .unwrap_or(AddressStatus::Cleared)
+        {
+            AddressStatus::Allowed => true,
+            AddressStatus::AllowedUntil(until) => e.ledger().timestamp() < until,
+            AddressStatus::Blocked | AddressStatus::Cleared => false,
+        }
+    }
+
+    pub fn get_address_status(e: Env, addr: Address) -> AddressStatus {
+        e.storage()
+            .instance()
+            .get(&DataKey::Status(addr))
+            .unwrap_or(AddressStatus::Cleared)
     }
 
     pub fn allow_address(e: Env, admin: Address, addr: Address) {
         admin.require_auth();
-        e.storage().instance().set(&DataKey::Allowed(addr), &true);
+        e.storage()
+            .instance()
+            .set(&DataKey::Status(addr), &AddressStatus::Allowed);
+        e.events()
+            .publish((Symbol::new(&e, "address_allowed"),), addr);
     }
 
     pub fn block_address(e: Env, admin: Address, addr: Address) {
         admin.require_auth();
-        e.storage().instance().set(&DataKey::Allowed(addr), &false);
+        e.storage()
+            .instance()
+            .set(&DataKey::Status(addr), &AddressStatus::Blocked);
+        e.events()
+            .publish((Symbol::new(&e, "address_blocked"),), addr);
     }
 
     pub fn allow_address_until(e: Env, admin: Address, addr: Address, until: u64) {
         admin.require_auth();
-        e.storage().instance().set(&DataKey::Allowed(addr), &true);
+        e.storage()
+            .instance()
+            .set(&DataKey::Status(addr), &AddressStatus::AllowedUntil(until));
+        e.events().publish(
+            (Symbol::new(&e, "address_allowed_until"),),
+            (addr, until),
+        );
     }
 
     pub fn transfer_admin(e: Env, admin: Address, new_admin: Address) {
@@ -57,7 +96,11 @@ impl ComplianceContract {
 
     pub fn clear_address(e: Env, admin: Address, addr: Address) {
         admin.require_auth();
-        e.storage().instance().set(&DataKey::Allowed(addr), &false);
+        e.storage()
+            .instance()
+            .set(&DataKey::Status(addr), &AddressStatus::Cleared);
+        e.events()
+            .publish((Symbol::new(&e, "address_cleared"),), addr);
     }
 
     pub fn pause(e: Env, admin: Address) {

--- a/COMEBACKHERE-contracts/contracts/treasury/src/lib.rs
+++ b/COMEBACKHERE-contracts/contracts/treasury/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, Symbol, Vec};
 
 #[contracttype]
 pub enum SettlementStatus {
@@ -107,6 +107,18 @@ impl TreasuryContract {
         Vec::new(&e)
     }
 
+    fn check_admin(e: &Env, admin: &Address) {
+        admin.require_auth();
+        let stored_admin: Address = e
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap();
+        if stored_admin != *admin {
+            panic_with_error!(&e, TreasuryError::Unauthorized);
+        }
+    }
+
     pub fn pause(e: Env, admin: Address) {
         admin.require_auth();
         e.storage().instance().set(&DataKey::Paused, &true);
@@ -115,6 +127,20 @@ impl TreasuryContract {
     pub fn unpause(e: Env, admin: Address) {
         admin.require_auth();
         e.storage().instance().set(&DataKey::Paused, &false);
+    }
+
+    pub fn update_threshold(e: Env, admin: Address, new_threshold: u32) {
+        Self::check_admin(&e, &admin);
+        if new_threshold == 0 {
+            panic_with_error!(&e, TreasuryError::InvalidThreshold);
+        }
+        let old_threshold: u64 = e.storage().instance().get(&DataKey::Threshold).unwrap_or(0u64);
+        let threshold = new_threshold as u64;
+        e.storage().instance().set(&DataKey::Threshold, &threshold);
+        e.events().publish(
+            (Symbol::new(&e, "threshold_updated"),),
+            (old_threshold, threshold),
+        );
     }
 
     pub fn raise_dispute(e: Env, signer: Address, settlement_id: u64, reason: u32) {
@@ -151,6 +177,8 @@ pub enum TreasuryError {
     ContractPaused = 1,
     NotPending = 2,
     InsufficientApprovals = 3,
+    InvalidThreshold = 4,
+    Unauthorized = 5,
 }
 
 #[contracttype]

--- a/abis/compliance.json
+++ b/abis/compliance.json
@@ -4,6 +4,7 @@
   "functions": [
     "initialize",
     "is_allowed",
+    "get_address_status",
     "allow_address",
     "block_address",
     "allow_address_until",

--- a/comebackhere-frontend/src/App.tsx
+++ b/comebackhere-frontend/src/App.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect } from "react"
 import { InvoicePayment } from "./components/InvoicePayment"
 import { RefundRequest } from "./components/RefundRequest"
+import { ComplianceManager } from "./components/ComplianceManager"
 import { useInvoice } from "./hooks/useInvoice"
 import { useWallet } from "./hooks/useWallet"
 import "./App.css"
 
-type Tab = "payment" | "refund"
+type Tab = "payment" | "refund" | "compliance"
 
 function RefundTab() {
   const { invoice, loading, error, loadInvoice, refund } = useInvoice()
@@ -114,10 +115,22 @@ export default function App() {
         >
           Request Refund
         </button>
+        <button
+          className={`tab ${tab === "compliance" ? "tab--active" : ""}`}
+          onClick={() => setTab("compliance")}
+        >
+          Compliance
+        </button>
       </nav>
 
       <main className="app-main">
-        {tab === "payment" ? <InvoicePayment /> : <RefundTab />}
+        {tab === "payment" ? (
+          <InvoicePayment />
+        ) : tab === "refund" ? (
+          <RefundTab />
+        ) : (
+          <ComplianceManager />
+        )}
       </main>
     </div>
   )

--- a/comebackhere-frontend/src/components/ComplianceManager.tsx
+++ b/comebackhere-frontend/src/components/ComplianceManager.tsx
@@ -1,0 +1,273 @@
+import { useMemo, useState } from "react"
+import {
+  allowAddress,
+  allowAddressUntil,
+  blockAddress,
+  clearAddress,
+  ComplianceStatus,
+  ComplianceStatusResult,
+  getAddressStatus,
+} from "../utils/compliance"
+
+interface ManagedAddress {
+  address: string
+  status: ComplianceStatus
+  expiresAt?: number | null
+  lastUpdated?: string
+}
+
+const statusLabels: Record<ComplianceStatus, string> = {
+  Allowed: "Allowed",
+  AllowedUntil: "Allowed until",
+  Blocked: "Blocked",
+  Cleared: "Cleared",
+}
+
+function ComplianceStatusBadge({ status }: { status: ComplianceStatus }) {
+  const cssClass = `badge badge--compliance-${status.toLowerCase()}`
+  return <span className={cssClass}>{statusLabels[status]}</span>
+}
+
+function isValidStellarAddress(value: string) {
+  return /^G[A-Z2-7]{55}$/.test(value.trim())
+}
+
+export function ComplianceManager() {
+  const [address, setAddress] = useState("")
+  const [expiry, setExpiry] = useState("")
+  const [status, setStatus] = useState<ComplianceStatusResult | null>(null)
+  const [managed, setManaged] = useState<ManagedAddress[]>([])
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [actionSubmitting, setActionSubmitting] = useState(false)
+
+  const addressValid = isValidStellarAddress(address)
+  const expiryTimestamp = useMemo(() => {
+    if (!expiry) return null
+    const parsed = new Date(expiry).getTime()
+    return Number.isFinite(parsed) ? Math.floor(parsed / 1000) : null
+  }, [expiry])
+
+  const addOrUpdateManaged = (entry: ManagedAddress) => {
+    setManaged((prev) => {
+      const existingIndex = prev.findIndex((item) => item.address === entry.address)
+      const updatedEntry = {
+        ...entry,
+        lastUpdated: new Date().toLocaleString(),
+      }
+      if (existingIndex >= 0) {
+        return prev.map((item, idx) => (idx === existingIndex ? updatedEntry : item))
+      }
+      return [updatedEntry, ...prev]
+    })
+  }
+
+  const handleFetchStatus = async () => {
+    setError(null)
+    setMessage(null)
+    if (!addressValid) {
+      setError("Enter a valid Stellar address starting with G and 56 chars.")
+      return
+    }
+    setLoading(true)
+    try {
+      const result = await getAddressStatus(address.trim())
+      setStatus(result)
+      addOrUpdateManaged({
+        address: address.trim(),
+        status: result.status,
+        expiresAt: result.expiresAt,
+      })
+      setMessage("Loaded current compliance status.")
+    } catch (err: any) {
+      setError(err?.message ?? "Failed to fetch address status")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const submitAction = async (
+    action: () => Promise<{ success: boolean; error?: string; hash?: string }>,
+    successText: string
+  ) => {
+    setError(null)
+    setMessage(null)
+    setActionSubmitting(true)
+    try {
+      const publicKey = (window as any).freighterApi
+        ? await (window as any).freighterApi.getAddress().then((res: any) => res.address)
+        : null
+      if (!publicKey) {
+        throw new Error("Connect your wallet to sign compliance updates.")
+      }
+      const result = await action()
+      if (!result.success) {
+        throw new Error(result.error ?? "Action failed")
+      }
+      setMessage(`${successText} Transaction hash: ${result.hash}`)
+      await handleFetchStatus()
+    } catch (err: any) {
+      setError(err?.message ?? "Action failed")
+    } finally {
+      setActionSubmitting(false)
+    }
+  }
+
+  const handleAllow = async () => {
+    if (!addressValid) {
+      setError("Enter a valid Stellar address starting with G and 56 chars.")
+      return
+    }
+    await submitAction(
+      async () => {
+        if (expiryTimestamp) {
+          return allowAddressUntil(address.trim(), expiryTimestamp, await (window as any).freighterApi.getAddress().then((res: any) => res.address))
+        }
+        return allowAddress(address.trim(), await (window as any).freighterApi.getAddress().then((res: any) => res.address))
+      },
+      expiryTimestamp ? "Allowed address until expiry." : "Address allowed."
+    )
+  }
+
+  const handleBlock = async () => {
+    if (!addressValid) {
+      setError("Enter a valid Stellar address starting with G and 56 chars.")
+      return
+    }
+    await submitAction(
+      async () => blockAddress(address.trim(), await (window as any).freighterApi.getAddress().then((res: any) => res.address)),
+      "Address blocked."
+    )
+  }
+
+  const handleClear = async () => {
+    if (!addressValid) {
+      setError("Enter a valid Stellar address starting with G and 56 chars.")
+      return
+    }
+    await submitAction(
+      async () => clearAddress(address.trim(), await (window as any).freighterApi.getAddress().then((res: any) => res.address)),
+      "Address cleared."
+    )
+  }
+
+  return (
+    <div className="compliance-manager">
+      <h1>Compliance Address Management</h1>
+
+      <div className="compliance-form">
+        <label>
+          Stellar Address
+          <input
+            type="text"
+            placeholder="G..."
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+          />
+        </label>
+
+        <label>
+          Allow Until (optional)
+          <input
+            type="datetime-local"
+            value={expiry}
+            onChange={(e) => setExpiry(e.target.value)}
+          />
+        </label>
+
+        <div className="compliance-actions">
+          <button
+            className="btn btn--secondary"
+            onClick={handleFetchStatus}
+            disabled={loading || actionSubmitting || !addressValid}
+          >
+            {loading ? "Fetching..." : "Fetch Status"}
+          </button>
+          <button
+            className="btn btn--primary"
+            onClick={handleAllow}
+            disabled={loading || actionSubmitting || !addressValid}
+          >
+            Allow Address
+          </button>
+          <button
+            className="btn btn--danger"
+            onClick={handleBlock}
+            disabled={loading || actionSubmitting || !addressValid}
+          >
+            Block Address
+          </button>
+          <button
+            className="btn btn--secondary"
+            onClick={handleClear}
+            disabled={loading || actionSubmitting || !addressValid}
+          >
+            Clear Address
+          </button>
+        </div>
+      </div>
+
+      {error && <div className="message message--error">{error}</div>}
+      {message && <div className="message message--success">{message}</div>}
+
+      {status && (
+        <div className="status-summary">
+          <h2>Current Status</h2>
+          <div className="detail-row">
+            <span className="detail-label">Status</span>
+            <span className="detail-value">
+              <ComplianceStatusBadge status={status.status} />
+            </span>
+          </div>
+          {status.expiresAt ? (
+            <div className="detail-row">
+              <span className="detail-label">Expires At</span>
+              <span className="detail-value">
+                {new Date(status.expiresAt * 1000).toLocaleString()}
+              </span>
+            </div>
+          ) : null}
+        </div>
+      )}
+
+      <div className="managed-table-wrapper">
+        <h2>Managed Addresses</h2>
+        <table className="managed-table">
+          <thead>
+            <tr>
+              <th>Address</th>
+              <th>Status</th>
+              <th>Expires At</th>
+              <th>Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {managed.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="empty-row">
+                  No managed addresses yet.
+                </td>
+              </tr>
+            ) : (
+              managed.map((entry) => (
+                <tr key={entry.address}>
+                  <td className="address-cell">{entry.address}</td>
+                  <td>
+                    <ComplianceStatusBadge status={entry.status} />
+                  </td>
+                  <td>
+                    {entry.expiresAt
+                      ? new Date(entry.expiresAt * 1000).toLocaleString()
+                      : "—"}
+                  </td>
+                  <td>{entry.lastUpdated ?? "—"}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/comebackhere-frontend/src/utils/compliance.ts
+++ b/comebackhere-frontend/src/utils/compliance.ts
@@ -1,0 +1,136 @@
+import {
+  Contract,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+  xdr,
+  nativeToScVal,
+} from "soroban-client"
+
+export type ComplianceStatus = "Allowed" | "AllowedUntil" | "Blocked" | "Cleared"
+
+export interface ComplianceStatusResult {
+  status: ComplianceStatus
+  expiresAt?: number | null
+}
+
+const COMPLIANCE_CONTRACT_ID =
+  import.meta.env.VITE_COMPLIANCE_CONTRACT_ID as string
+const SOROBAN_RPC = import.meta.env.VITE_SOROBAN_RPC as string
+const NETWORK_PASSPHRASE = import.meta.env.VITE_NETWORK_PASSPHRASE as string
+
+function getNetworkPassphrase(): string {
+  return NETWORK_PASSPHRASE || Networks.STANDALONE
+}
+
+function getServer() {
+  const { SorobanRpc } = window as any
+  return new SorobanRpc.Server(SOROBAN_RPC)
+}
+
+function parseAddressStatus(scVal: xdr.ScVal): ComplianceStatusResult {
+  const vec = scVal.vec()
+  const variant = vec?.[0]?.sym()?.toString() ?? "Cleared"
+  if (variant === "AllowedUntil") {
+    const until = vec?.[1]?.u64()?.toNumber() ?? 0
+    return { status: variant as ComplianceStatus, expiresAt: until }
+  }
+  return { status: variant as ComplianceStatus, expiresAt: null }
+}
+
+export async function getAddressStatus(
+  address: string
+): Promise<ComplianceStatusResult> {
+  const server = getServer()
+  const contract = new Contract(COMPLIANCE_CONTRACT_ID)
+  const args = [nativeToScVal(address, { type: "address" })]
+
+  const result = await server.simulateTransaction(
+    new TransactionBuilder(await server.getAccount(COMPLIANCE_CONTRACT_ID), {
+      fee: BASE_FEE,
+      networkPassphrase: getNetworkPassphrase(),
+    })
+      .addOperation(contract.call("get_address_status", ...args))
+      .setTimeout(30)
+      .build()
+  )
+
+  if (!result.result || !result.result.retval) {
+    throw new Error("Unable to fetch address status")
+  }
+
+  return parseAddressStatus(result.result.retval)
+}
+
+async function submitTransaction(
+  publicKey: string,
+  operation: string,
+  args: xdr.ScVal[]
+): Promise<{ success: boolean; error?: string; hash?: string }> {
+  try {
+    const server = getServer()
+    const contract = new Contract(COMPLIANCE_CONTRACT_ID)
+    const account = await server.getAccount(publicKey)
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: getNetworkPassphrase(),
+    })
+      .addOperation(contract.call(operation, ...args))
+      .setTimeout(30)
+      .build()
+
+    const simulated = await server.simulateTransaction(tx)
+    const { SorobanRpc } = window as any
+    const prepare = SorobanRpc.assembleTransaction(tx, simulated)
+    const signed = await (window as any).freighterApi.signTransaction(
+      prepare.toXDR(),
+      { networkPassphrase: getNetworkPassphrase() }
+    )
+
+    const txHash = await server.sendTransaction(signed)
+    return { success: true, hash: txHash.hash }
+  } catch (err: any) {
+    return {
+      success: false,
+      error: err?.message ?? err?.toString() ?? "Contract transaction failed",
+    }
+  }
+}
+
+export async function allowAddress(
+  address: string,
+  publicKey: string
+): Promise<{ success: boolean; error?: string; hash?: string }> {
+  return submitTransaction(publicKey, "allow_address", [
+    nativeToScVal(address, { type: "address" }),
+  ])
+}
+
+export async function blockAddress(
+  address: string,
+  publicKey: string
+): Promise<{ success: boolean; error?: string; hash?: string }> {
+  return submitTransaction(publicKey, "block_address", [
+    nativeToScVal(address, { type: "address" }),
+  ])
+}
+
+export async function clearAddress(
+  address: string,
+  publicKey: string
+): Promise<{ success: boolean; error?: string; hash?: string }> {
+  return submitTransaction(publicKey, "clear_address", [
+    nativeToScVal(address, { type: "address" }),
+  ])
+}
+
+export async function allowAddressUntil(
+  address: string,
+  untilTimestamp: number,
+  publicKey: string
+): Promise<{ success: boolean; error?: string; hash?: string }> {
+  return submitTransaction(publicKey, "allow_address_until", [
+    nativeToScVal(address, { type: "address" }),
+    nativeToScVal(untilTimestamp, { type: "u64" }),
+  ])
+}

--- a/comebackhere-frontend/src/vite-env.d.ts
+++ b/comebackhere-frontend/src/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
   readonly VITE_HORIZON_URL: string
   readonly VITE_NETWORK_PASSPHRASE: string
   readonly VITE_INVOICE_CONTRACT_ID: string
+  readonly VITE_COMPLIANCE_CONTRACT_ID: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
closes #33 
closes #34 
closes #35 
closes #36 


Description
Add an update_threshold function to the treasury contract that allows the admin to change the signer weight threshold required for settlement execution. The function must reject a zero value to prevent the contract from becoming permanently executable without any signer approval, and must emit an event when the threshold changes.

Requirements and context
Add update_threshold(new_threshold: u32) — admin-only
Reject new_threshold == 0 with an appropriate error (e.g. InvalidThreshold)
Persist new value to DataKey::Threshold
Emit threshold_updated(old_threshold, new_threshold) event
Add unit tests: update to valid value, reject zero, reject non-admin caller
Follow existing project conventions