### PR TITLE
chore: branch protection docs, get_pending_settlements pagination, ABI explorer, CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS — critical paths require review from designated owners before merge.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+contracts/  @dreamgeneX
+scripts/    @dreamgeneX
+docs/       @dreamgeneX
+
+# Frontend — assign a frontend team owner when one is established.
+# comebackhere-frontend/  @frontend-team

--- a/COMEBACKHERE-contracts/contracts/treasury/src/lib.rs
+++ b/COMEBACKHERE-contracts/contracts/treasury/src/lib.rs
@@ -103,8 +103,42 @@ impl TreasuryContract {
         }
     }
 
-    pub fn get_pending_settlements(e: Env) -> Vec<u64> {
-        Vec::new(&e)
+    pub fn get_pending_settlements(
+        e: Env,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    ) -> Vec<u64> {
+        let next_id: u64 = e
+            .storage()
+            .instance()
+            .get(&DataKey::NextSettlementId)
+            .unwrap_or(1u64);
+        let cap: u32 = limit.unwrap_or(100).min(100);
+        let skip: u32 = offset.unwrap_or(0);
+
+        let mut result: Vec<u64> = Vec::new(&e);
+        let mut matched: u32 = 0;
+        let mut collected: u32 = 0;
+
+        for id in 1..next_id {
+            if let Some(s) = e
+                .storage()
+                .instance()
+                .get::<DataKey, Settlement>(&DataKey::Settlement(id))
+            {
+                if matches!(s.status, SettlementStatus::Pending) {
+                    if matched >= skip {
+                        if collected >= cap {
+                            break;
+                        }
+                        result.push_back(id);
+                        collected += 1;
+                    }
+                    matched += 1;
+                }
+            }
+        }
+        result
     }
 
     pub fn pause(e: Env, admin: Address) {
@@ -161,4 +195,117 @@ pub enum DataKey {
     Settlement(u64),
     NextSettlementId,
     Threshold,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    fn setup() -> (Env, soroban_sdk::Address) {
+        let e = Env::default();
+        e.mock_all_auths();
+        let contract_id = e.register_contract(None, TreasuryContract);
+        (e, contract_id)
+    }
+
+    fn client(e: &Env, id: &soroban_sdk::Address) -> TreasuryContractClient {
+        TreasuryContractClient::new(e, id)
+    }
+
+    #[test]
+    fn test_empty_returns_empty() {
+        let (e, id) = setup();
+        let c = client(&e, &id);
+        let admin = soroban_sdk::Address::generate(&e);
+        c.initialize(&soroban_sdk::vec![&e], &1, &admin);
+        let result = c.get_pending_settlements(&None, &None);
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_single_pending() {
+        let (e, id) = setup();
+        let c = client(&e, &id);
+        let admin = soroban_sdk::Address::generate(&e);
+        let token = soroban_sdk::Address::generate(&e);
+        let merchant = soroban_sdk::Address::generate(&e);
+        let signer = soroban_sdk::Address::generate(&e);
+        c.initialize(
+            &soroban_sdk::vec![&e, (signer.clone(), 1u64)],
+            &1,
+            &admin,
+        );
+        let sid = c.propose_settlement(&signer, &token, &1000u64, &merchant);
+        let result = c.get_pending_settlements(&None, &None);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(0).unwrap(), sid);
+    }
+
+    #[test]
+    fn test_mixed_statuses_filtered() {
+        let (e, id) = setup();
+        let c = client(&e, &id);
+        let admin = soroban_sdk::Address::generate(&e);
+        let token = soroban_sdk::Address::generate(&e);
+        let merchant = soroban_sdk::Address::generate(&e);
+        let signer = soroban_sdk::Address::generate(&e);
+        c.initialize(
+            &soroban_sdk::vec![&e, (signer.clone(), 2u64)],
+            &1,
+            &admin,
+        );
+        let s1 = c.propose_settlement(&signer, &token, &1000u64, &merchant);
+        let s2 = c.propose_settlement(&signer, &token, &2000u64, &merchant);
+        // execute s1 so it is no longer Pending
+        c.approve_settlement(&signer, &s1);
+        c.execute_settlement(&signer, &s1, &token);
+        let result = c.get_pending_settlements(&None, &None);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(0).unwrap(), s2);
+    }
+
+    #[test]
+    fn test_pagination_offset_and_limit() {
+        let (e, id) = setup();
+        let c = client(&e, &id);
+        let admin = soroban_sdk::Address::generate(&e);
+        let token = soroban_sdk::Address::generate(&e);
+        let merchant = soroban_sdk::Address::generate(&e);
+        let signer = soroban_sdk::Address::generate(&e);
+        c.initialize(
+            &soroban_sdk::vec![&e, (signer.clone(), 1u64)],
+            &1,
+            &admin,
+        );
+        for _ in 0..5 {
+            c.propose_settlement(&signer, &token, &100u64, &merchant);
+        }
+        // offset=2, limit=2 → ids 3 and 4
+        let page = c.get_pending_settlements(&Some(2u32), &Some(2u32));
+        assert_eq!(page.len(), 2);
+        assert_eq!(page.get(0).unwrap(), 3u64);
+        assert_eq!(page.get(1).unwrap(), 4u64);
+    }
+
+    #[test]
+    fn test_limit_capped_at_100() {
+        let (e, id) = setup();
+        let c = client(&e, &id);
+        let admin = soroban_sdk::Address::generate(&e);
+        let token = soroban_sdk::Address::generate(&e);
+        let merchant = soroban_sdk::Address::generate(&e);
+        let signer = soroban_sdk::Address::generate(&e);
+        c.initialize(
+            &soroban_sdk::vec![&e, (signer.clone(), 1u64)],
+            &1,
+            &admin,
+        );
+        for _ in 0..5 {
+            c.propose_settlement(&signer, &token, &100u64, &merchant);
+        }
+        // limit=200 should be capped to 100, returning all 5
+        let result = c.get_pending_settlements(&None, &Some(200u32));
+        assert_eq!(result.len(), 5);
+    }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,26 @@ Run all hooks manually:
 pre-commit run --all-files
 ```
 
+## Branch Protection
+
+The `main` branch is protected. Direct pushes are not allowed; all changes must go through a pull request.
+
+### Required status checks
+
+All of the following checks must pass before a PR can be merged:
+
+- `contract-build` — Soroban contract compilation
+- `contract-tests` — contract unit and integration tests
+- `abi-snapshot-hygiene` — ABI metadata in `abis/` is consistent with contract source
+- `markdown-lint` — documentation linting
+- `frontend-build` — frontend build succeeds
+
+### Required reviews
+
+- At least **1 approving review** is required for all PRs.
+- At least **2 approving reviews** are required for PRs that touch mainnet-related paths
+  (`docs/MAINNET_DEPLOYMENT.md`, deployment scripts, or governance configuration).
+
 ## ABI snapshots
 
 After changing contract interfaces (in `COMEBACKHERE-contracts/`), regenerate and verify ABI metadata:

--- a/dashboard/abi-explorer.html
+++ b/dashboard/abi-explorer.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ABI Explorer — COMEBACKHERE Protocol</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  .contract-section { margin-bottom: 24px; }
+  .contract-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 20px;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    cursor: pointer;
+    user-select: none;
+  }
+  .contract-header:hover { background: #f9fafb; }
+  .contract-header h2 { font-size: 1rem; font-weight: 700; flex: 1; margin: 0; }
+  .contract-header .version { font-size: 0.75rem; color: #6b7280; }
+  .contract-header .chevron { font-size: 0.75rem; color: #6b7280; transition: transform 0.2s; }
+  .contract-header.open .chevron { transform: rotate(90deg); }
+  .fn-list {
+    display: none;
+    background: #fff;
+    border-radius: 0 0 8px 8px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    border-top: 1px solid #e5e7eb;
+    overflow: hidden;
+  }
+  .fn-list.open { display: block; }
+  .fn-row {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    padding: 10px 20px;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 0.875rem;
+  }
+  .fn-row:last-child { border-bottom: none; }
+  .fn-row:hover { background: #f9fafb; }
+  .fn-name { font-family: monospace; font-weight: 600; min-width: 220px; color: #4f46e5; }
+  .fn-params { color: #374151; flex: 1; font-family: monospace; font-size: 0.8rem; }
+  .fn-returns { font-family: monospace; font-size: 0.8rem; color: #065f46; white-space: nowrap; }
+  .fn-returns::before { content: "→ "; color: #9ca3af; }
+  .empty-params { color: #9ca3af; font-style: italic; }
+</style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>ABI Explorer</h1>
+      <p style="color:#6b7280;font-size:0.875rem;margin-top:4px">
+        Read-only reference for deployed COMEBACKHERE Protocol contracts.
+      </p>
+    </header>
+    <div id="explorer"></div>
+  </div>
+
+  <script>
+    const ABIS = [
+      {
+        "contract": "invoice",
+        "version": "1.1.0",
+        "functions": [
+          "initialize",
+          "create_invoice",
+          "mark_paid",
+          "get_invoice",
+          "get_invoice_status",
+          "cancel_invoice",
+          "request_refund",
+          "batch_expire(offset: u32, limit: u32, returns: u32)",
+          "pause",
+          "unpause",
+          "set_grace_window",
+          "get_grace_window",
+          "release_escrow"
+        ]
+      },
+      {
+        "contract": "treasury",
+        "version": "1.0.0",
+        "functions": [
+          "initialize",
+          "set_signer",
+          "propose_settlement",
+          "propose_partial_settlement",
+          "approve_settlement",
+          "approve_partial_settlement",
+          "execute_settlement",
+          "partially_execute_settlement",
+          "cancel_settlement",
+          "get_pending_settlements(offset: Option<u32>, limit: Option<u32>, returns: Vec<u64>)",
+          "get_pending_settlements_page",
+          "get_settlement",
+          "update_threshold",
+          "pause",
+          "unpause",
+          "raise_dispute",
+          "resolve_dispute",
+          "vote_dispute_resolution",
+          "deposit",
+          "withdraw",
+          "add_allowed_token",
+          "remove_allowed_token",
+          "get_allowed_tokens",
+          "propose_signer_rotation",
+          "approve_signer_rotation",
+          "update_merchant_payout_address",
+          "get_merchant_payout_address",
+          "hold_settlement",
+          "release_hold"
+        ]
+      },
+      {
+        "contract": "compliance",
+        "version": "1.0.0",
+        "functions": [
+          "initialize",
+          "is_allowed",
+          "allow_address",
+          "block_address",
+          "allow_address_until",
+          "transfer_admin",
+          "accept_admin",
+          "clear_address",
+          "pause",
+          "unpause"
+        ]
+      }
+    ];
+
+    // Parse "name(param: type, ..., returns: type)" into { name, params, returns }
+    function parseFn(raw) {
+      const parenOpen = raw.indexOf('(');
+      if (parenOpen === -1) return { name: raw.trim(), params: [], returns: null };
+
+      const name = raw.slice(0, parenOpen).trim();
+      const inner = raw.slice(parenOpen + 1, raw.lastIndexOf(')')).trim();
+      const parts = inner.split(',').map(s => s.trim()).filter(Boolean);
+
+      let returns = null;
+      const params = [];
+      for (const p of parts) {
+        if (p.startsWith('returns:')) {
+          returns = p.replace('returns:', '').trim();
+        } else {
+          params.push(p);
+        }
+      }
+      return { name, params, returns };
+    }
+
+    function renderContract(abi) {
+      const id = 'contract-' + abi.contract;
+      const fnRows = abi.functions.map(raw => {
+        const { name, params, returns } = parseFn(raw);
+        const paramsHtml = params.length
+          ? params.map(p => `<span>${p}</span>`).join('<span style="color:#9ca3af">, </span>')
+          : '<span class="empty-params">no params</span>';
+        const returnsHtml = returns
+          ? `<span class="fn-returns">${returns}</span>`
+          : '';
+        return `<div class="fn-row">
+          <span class="fn-name">${name}</span>
+          <span class="fn-params">${paramsHtml}</span>
+          ${returnsHtml}
+        </div>`;
+      }).join('');
+
+      return `<div class="contract-section">
+        <div class="contract-header" data-target="${id}" onclick="toggleSection(this)">
+          <h2>${abi.contract}</h2>
+          <span class="version">v${abi.version}</span>
+          <span class="badge" style="background:#e0e7ff;color:#3730a3">${abi.functions.length} functions</span>
+          <span class="chevron">▶</span>
+        </div>
+        <div class="fn-list" id="${id}">${fnRows}</div>
+      </div>`;
+    }
+
+    function toggleSection(header) {
+      const target = document.getElementById(header.dataset.target);
+      header.classList.toggle('open');
+      target.classList.toggle('open');
+    }
+
+    document.getElementById('explorer').innerHTML = ABIS.map(renderContract).join('');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Four improvements in one PR:

**CONTRIBUTING.md — Branch Protection**
- New section documenting required status checks: `contract-build`, `contract-tests`, `abi-snapshot-hygiene`, `markdown-lint`, `frontend-build`
- 1 approving review required for all PRs; 2 for mainnet-related changes
- Direct pushes to `main` are not allowed

**treasury/lib.rs — `get_pending_settlements` pagination**
- Replaced stub with full implementation: filters `Pending` settlements, supports `offset`/`limit` params, caps at 100 results
- 5 unit tests: empty result, single pending, mixed-status filtering, offset+limit pagination, limit cap

**dashboard/abi-explorer.html — ABI Explorer page**
- Read-only page listing all functions for invoice, treasury, and compliance contracts
- Grouped by contract with collapsible sections; shows function name, parameters, and return type
- Follows existing `dashboard/` conventions (plain HTML + inline JS + shared CSS)

**\.github/CODEOWNERS**
- `@dreamgeneX` required reviewer for `contracts/`, `scripts/`, `docs/`
- Frontend owner placeholder commented out for future assignment

## Tested
No compilation or test run per instructions.