### PR TITLE
feat: implement signer management UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,8 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import DashboardLayout from "./components/Dashboard/DashboardLayout";
 import SettlementProposalForm from "./components/SettlementProposal/SettlementProposalForm";
 import DisputeVotingPanel from "./components/DisputeVoting/DisputeVotingPanel";
+import SignerManagement from "./components/SignerManagement/SignerManagement";
+import ABIExplorer from "./components/ABIExplorer";
 
 function InvoicesPage() {
   return <p>Invoices list will appear here.</p>;
@@ -13,6 +15,10 @@ function SettlementsPage() {
 
 function DisputesPage() {
   return <DisputeVotingPanel />;
+}
+
+function SignersPage() {
+  return <SignerManagement />;
 }
 
 function SettingsPage() {
@@ -27,6 +33,7 @@ export default function App() {
         <Route path="invoices" element={<InvoicesPage />} />
         <Route path="settlements" element={<SettlementsPage />} />
         <Route path="disputes" element={<DisputesPage />} />
+        <Route path="signers" element={<SignersPage />} />
         <Route path="settings" element={<SettingsPage />} />
         <Route path="abi" element={<ABIExplorer />} />
       </Route>

--- a/frontend/src/components/Dashboard/Sidebar.tsx
+++ b/frontend/src/components/Dashboard/Sidebar.tsx
@@ -5,6 +5,7 @@ const links = [
   { to: "/invoices", label: "Invoices", icon: "receipt" },
   { to: "/settlements", label: "Settlements", icon: "account_balance" },
   { to: "/disputes", label: "Disputes", icon: "gavel" },
+  { to: "/signers", label: "Signers", icon: "signers" },
   { to: "/settings", label: "Settings", icon: "settings" },
 ];
 
@@ -12,6 +13,7 @@ const iconMap: Record<string, string> = {
   receipt: "\u{1F4CB}",
   account_balance: "\u{1F3E6}",
   gavel: "\u{2696}\u{FE0F}",
+  signers: "\u{1F511}",
   settings: "\u{2699}\u{FE0F}",
 };
 

--- a/frontend/src/components/SignerManagement/SignerManagement.css
+++ b/frontend/src/components/SignerManagement/SignerManagement.css
@@ -1,0 +1,259 @@
+.signer-panel {
+  max-width: 720px;
+}
+
+.signer-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.signer-panel__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.signer-panel__error {
+  color: var(--color-danger);
+  font-size: 0.875rem;
+  margin-bottom: 12px;
+}
+
+/* Table */
+.signer-table-wrap {
+  background: var(--color-card-bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  margin-bottom: 24px;
+  overflow-x: auto;
+}
+
+.signer-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.signer-th {
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.signer-td {
+  padding: 12px 16px;
+  font-size: 0.875rem;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.signer-row:last-child .signer-td {
+  border-bottom: none;
+}
+
+.signer-td--address {
+  font-family: ui-monospace, "Cascadia Code", monospace;
+}
+
+.address-full {
+  display: none;
+}
+
+.address-short {
+  display: inline;
+}
+
+@media (min-width: 640px) {
+  .address-full {
+    display: inline;
+  }
+  .address-short {
+    display: none;
+  }
+}
+
+.weight-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  background: #e0e7ff;
+  color: #3730a3;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.signer-empty {
+  padding: 24px 16px;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+}
+
+/* Add Signer Form */
+.add-signer-form {
+  background: var(--color-card-bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 20px 24px;
+}
+
+.signer-section-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--color-text);
+  margin-bottom: 16px;
+}
+
+.form-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.form-field--weight {
+  flex: 0 0 90px;
+}
+
+.form-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.form-input {
+  padding: 8px 12px;
+  border: 1px solid var(--color-input-border);
+  border-radius: var(--radius);
+  background: var(--color-input-bg);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  transition: border-color 0.15s;
+  width: 100%;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.form-input--error {
+  border-color: var(--color-danger);
+}
+
+.form-error {
+  font-size: 0.78rem;
+  color: var(--color-danger);
+  margin-top: 2px;
+}
+
+.form-submit-btn {
+  margin-top: 22px;
+  white-space: nowrap;
+  align-self: flex-start;
+}
+
+/* Buttons */
+.btn {
+  padding: 8px 16px;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.btn--sm {
+  padding: 4px 10px;
+  font-size: 0.78rem;
+}
+
+.btn--primary {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.btn--primary:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+.btn--secondary {
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
+.btn--secondary:hover:not(:disabled) {
+  background: var(--color-bg);
+}
+
+.btn--danger {
+  background: var(--color-danger);
+  color: #fff;
+}
+
+.btn--danger:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+/* Modal */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal {
+  background: var(--color-card-bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
+  padding: 28px 32px;
+  max-width: 420px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.modal__title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.modal__message {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.modal__actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}

--- a/frontend/src/components/SignerManagement/SignerManagement.tsx
+++ b/frontend/src/components/SignerManagement/SignerManagement.tsx
@@ -1,0 +1,254 @@
+import { useState } from 'react'
+import { useSigners } from '../../hooks/useSigners'
+import { SignerInfo } from '../../types'
+import './SignerManagement.css'
+
+const STELLAR_ADDRESS_RE = /^[G][A-Z0-9]{55}$/
+
+function shorten(addr: string): string {
+  if (!addr || addr.length < 12) return addr
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`
+}
+
+function ConfirmModal({
+  title,
+  message,
+  onConfirm,
+  onCancel,
+  danger,
+}: {
+  title: string
+  message: string
+  onConfirm: () => void
+  onCancel: () => void
+  danger?: boolean
+}) {
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <div className="modal">
+        <h3 id="modal-title" className="modal__title">{title}</h3>
+        <p className="modal__message">{message}</p>
+        <div className="modal__actions">
+          <button className="btn btn--secondary" onClick={onCancel}>Cancel</button>
+          <button
+            className={`btn ${danger ? 'btn--danger' : 'btn--primary'}`}
+            onClick={onConfirm}
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function AddSignerForm({ onAdd }: { onAdd: (address: string, weight: number) => Promise<void> }) {
+  const [address, setAddress] = useState('')
+  const [weight, setWeight] = useState('')
+  const [addressErr, setAddressErr] = useState('')
+  const [weightErr, setWeightErr] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [submitErr, setSubmitErr] = useState('')
+
+  const validateAddress = (val: string) => {
+    if (!STELLAR_ADDRESS_RE.test(val)) {
+      setAddressErr('Invalid Stellar address (G + 55 alphanumeric chars)')
+      return false
+    }
+    setAddressErr('')
+    return true
+  }
+
+  const validateWeight = (val: string) => {
+    const n = parseInt(val, 10)
+    if (!val || isNaN(n) || n <= 0 || !Number.isInteger(n)) {
+      setWeightErr('Weight must be a positive integer')
+      return false
+    }
+    setWeightErr('')
+    return true
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSubmitErr('')
+    const addrOk = validateAddress(address)
+    const wtOk = validateWeight(weight)
+    if (!addrOk || !wtOk) return
+    setSubmitting(true)
+    try {
+      await onAdd(address, parseInt(weight, 10))
+      setAddress('')
+      setWeight('')
+    } catch (err: any) {
+      setSubmitErr(err.message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form className="add-signer-form" onSubmit={handleSubmit} noValidate>
+      <h3 className="signer-section-title">Add Signer</h3>
+      <div className="form-row">
+        <div className="form-field">
+          <label className="form-label" htmlFor="signer-address">Address</label>
+          <input
+            id="signer-address"
+            className={`form-input${addressErr ? ' form-input--error' : ''}`}
+            type="text"
+            placeholder="GXXXXXXX..."
+            maxLength={56}
+            value={address}
+            onChange={e => { setAddress(e.target.value); if (addressErr) validateAddress(e.target.value) }}
+            onBlur={() => address && validateAddress(address)}
+          />
+          {addressErr && <p className="form-error">{addressErr}</p>}
+        </div>
+        <div className="form-field form-field--weight">
+          <label className="form-label" htmlFor="signer-weight">Weight</label>
+          <input
+            id="signer-weight"
+            className={`form-input${weightErr ? ' form-input--error' : ''}`}
+            type="number"
+            min="1"
+            step="1"
+            placeholder="1"
+            value={weight}
+            onChange={e => { setWeight(e.target.value); if (weightErr) validateWeight(e.target.value) }}
+            onBlur={() => weight && validateWeight(weight)}
+          />
+          {weightErr && <p className="form-error">{weightErr}</p>}
+        </div>
+        <button className="btn btn--primary form-submit-btn" type="submit" disabled={submitting}>
+          {submitting ? 'Adding...' : 'Add Signer'}
+        </button>
+      </div>
+      {submitErr && <p className="form-error">{submitErr}</p>}
+    </form>
+  )
+}
+
+function SignerRow({
+  signer,
+  onRemove,
+}: {
+  signer: SignerInfo
+  onRemove: (address: string) => void
+}) {
+  return (
+    <tr className="signer-row">
+      <td className="signer-td signer-td--address" title={signer.address}>
+        <span className="address-full">{signer.address}</span>
+        <span className="address-short">{shorten(signer.address)}</span>
+      </td>
+      <td className="signer-td">
+        <span className="weight-badge">{signer.weight}</span>
+      </td>
+      <td className="signer-td">
+        <button
+          className="btn btn--danger btn--sm"
+          onClick={() => onRemove(signer.address)}
+          aria-label={`Remove signer ${shorten(signer.address)}`}
+        >
+          Remove
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+export default function SignerManagement() {
+  const { signers, loading, error, addSigner, removeSigner, rotateSigners } = useSigners()
+  const [removeTarget, setRemoveTarget] = useState<string | null>(null)
+  const [showRotateConfirm, setShowRotateConfirm] = useState(false)
+  const [actionErr, setActionErr] = useState<string | null>(null)
+
+  const handleRemoveConfirm = async () => {
+    if (!removeTarget) return
+    setActionErr(null)
+    try {
+      await removeSigner(removeTarget)
+    } catch (e: any) {
+      setActionErr(`Failed to remove signer: ${e.message}`)
+    } finally {
+      setRemoveTarget(null)
+    }
+  }
+
+  const handleRotateConfirm = async () => {
+    setActionErr(null)
+    setShowRotateConfirm(false)
+    try {
+      await rotateSigners()
+    } catch (e: any) {
+      setActionErr(`Failed to rotate signers: ${e.message}`)
+    }
+  }
+
+  if (loading && signers.length === 0) {
+    return <div className="signer-panel"><p>Loading signers...</p></div>
+  }
+
+  if (error && signers.length === 0) {
+    return <div className="signer-panel"><p className="signer-panel__error">Error: {error}</p></div>
+  }
+
+  return (
+    <div className="signer-panel">
+      <div className="signer-panel__header">
+        <h2 className="signer-panel__title">Signer Management</h2>
+        <button
+          className="btn btn--secondary"
+          onClick={() => setShowRotateConfirm(true)}
+        >
+          Trigger Rotation
+        </button>
+      </div>
+
+      {actionErr && <p className="signer-panel__error">{actionErr}</p>}
+
+      <div className="signer-table-wrap">
+        {signers.length === 0 ? (
+          <p className="signer-empty">No signers configured.</p>
+        ) : (
+          <table className="signer-table">
+            <thead>
+              <tr>
+                <th className="signer-th">Address</th>
+                <th className="signer-th">Weight</th>
+                <th className="signer-th">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {signers.map(s => (
+                <SignerRow key={s.address} signer={s} onRemove={setRemoveTarget} />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <AddSignerForm onAdd={addSigner} />
+
+      {removeTarget && (
+        <ConfirmModal
+          title="Remove Signer"
+          message={`Remove signer ${shorten(removeTarget)}? This action cannot be undone.`}
+          onConfirm={handleRemoveConfirm}
+          onCancel={() => setRemoveTarget(null)}
+          danger
+        />
+      )}
+
+      {showRotateConfirm && (
+        <ConfirmModal
+          title="Trigger Signer Rotation"
+          message="This will initiate a signer rotation on the treasury contract. Are you sure?"
+          onConfirm={handleRotateConfirm}
+          onCancel={() => setShowRotateConfirm(false)}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useSigners.ts
+++ b/frontend/src/hooks/useSigners.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect, useCallback } from 'react'
+import { SignerInfo } from '../types'
+
+const API_BASE = '/api'
+
+export function useSigners() {
+  const [signers, setSigners] = useState<SignerInfo[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchSigners = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const res = await fetch(`${API_BASE}/treasury/signers`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setSigners(await res.json())
+    } catch (e: any) {
+      setError(e.message || 'Failed to fetch signers')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { fetchSigners() }, [fetchSigners])
+
+  const addSigner = useCallback(async (address: string, weight: number) => {
+    const res = await fetch(`${API_BASE}/treasury/add-signer`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address, weight }),
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const updated: SignerInfo = await res.json()
+    setSigners(prev => {
+      const idx = prev.findIndex(s => s.address === address)
+      return idx >= 0
+        ? prev.map(s => s.address === address ? updated : s)
+        : [...prev, updated]
+    })
+  }, [])
+
+  const removeSigner = useCallback(async (address: string) => {
+    const res = await fetch(`${API_BASE}/treasury/remove-signer`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address }),
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    setSigners(prev => prev.filter(s => s.address !== address))
+  }, [])
+
+  const rotateSigners = useCallback(async () => {
+    const res = await fetch(`${API_BASE}/treasury/rotate-signers`, { method: 'POST' })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    await fetchSigners()
+  }, [fetchSigners])
+
+  return { signers, loading, error, addSigner, removeSigner, rotateSigners, refresh: fetchSigners }
+}


### PR DESCRIPTION
- Add useSigners hook (fetchSigners, addSigner, removeSigner, rotateSigners) calling /api/treasury/* endpoints
- Add SignerManagement component with:
  - Signer table listing addresses and weight badges
  - Add signer form with Stellar address and positive-integer weight validation
  - Remove signer with confirmation modal
  - Trigger signer rotation with confirmation modal
- Wire /signers route in App.tsx
- Add Signers nav link to Sidebar

Closes #49 