### PR TITLE
feat: add backend REST endpoint POST /settlements/:id/approve

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["invoice", "settlement"]
+resolver = "2"

--- a/contracts/settlement/Cargo.toml
+++ b/contracts/settlement/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "comebackhere-settlement"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = "21"
+
+[dev-dependencies]
+soroban-sdk = { version = "21", features = ["testutils"] }

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -1,0 +1,265 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, Vec};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SettlementStatus {
+    Pending,
+    Executed,
+    Cancelled,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Settlement {
+    pub merchant: Address,
+    pub amount: u64,
+    pub status: SettlementStatus,
+    pub approval_weight: u64,
+    pub approvals: Vec<Address>,
+}
+
+#[contracttype]
+pub struct ApproveResult {
+    pub approval_weight: u64,
+    pub threshold: u64,
+}
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum SettlementError {
+    NotFound = 1,
+    Unauthorized = 2,
+    AlreadyApproved = 3,
+    NotPending = 4,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Threshold,
+    Signer(Address),
+    Settlement(u64),
+    NextId,
+}
+
+#[contract]
+pub struct SettlementContract;
+
+#[contractimpl]
+impl SettlementContract {
+    /// Initialize with signers (address, weight pairs) and approval threshold.
+    pub fn initialize(e: Env, signers: Vec<(Address, u64)>, threshold: u64) {
+        e.storage().instance().set(&DataKey::Threshold, &threshold);
+        e.storage().instance().set(&DataKey::NextId, &1u64);
+        for (signer, weight) in signers.iter() {
+            e.storage()
+                .instance()
+                .set(&DataKey::Signer(signer.clone()), &weight);
+        }
+    }
+
+    /// Propose a new settlement; returns the settlement ID.
+    pub fn propose(e: Env, proposer: Address, merchant: Address, amount: u64) -> u64 {
+        proposer.require_auth();
+        let id: u64 = e
+            .storage()
+            .instance()
+            .get(&DataKey::NextId)
+            .unwrap_or(1u64);
+        let s = Settlement {
+            merchant,
+            amount,
+            status: SettlementStatus::Pending,
+            approval_weight: 0,
+            approvals: Vec::new(&e),
+        };
+        e.storage().instance().set(&DataKey::Settlement(id), &s);
+        e.storage().instance().set(&DataKey::NextId, &(id + 1));
+        id
+    }
+
+    /// Approve a pending settlement.
+    ///
+    /// Returns the current `approval_weight` and required `threshold` so callers
+    /// can track progress toward execution.
+    ///
+    /// Errors:
+    /// - `NotFound`      – settlement ID does not exist
+    /// - `Unauthorized`  – signer has no registered weight
+    /// - `AlreadyApproved` – signer has already approved this settlement
+    /// - `NotPending`    – settlement is not in Pending status
+    pub fn approve_settlement(
+        e: Env,
+        signer: Address,
+        settlement_id: u64,
+    ) -> Result<ApproveResult, SettlementError> {
+        signer.require_auth();
+
+        let weight: u64 = e
+            .storage()
+            .instance()
+            .get(&DataKey::Signer(signer.clone()))
+            .unwrap_or(0);
+        if weight == 0 {
+            return Err(SettlementError::Unauthorized);
+        }
+
+        let mut settlement: Settlement = e
+            .storage()
+            .instance()
+            .get(&DataKey::Settlement(settlement_id))
+            .ok_or(SettlementError::NotFound)?;
+
+        if settlement.status != SettlementStatus::Pending {
+            return Err(SettlementError::NotPending);
+        }
+
+        if settlement.approvals.contains(&signer) {
+            return Err(SettlementError::AlreadyApproved);
+        }
+
+        settlement.approval_weight += weight;
+        settlement.approvals.push_back(signer);
+        e.storage()
+            .instance()
+            .set(&DataKey::Settlement(settlement_id), &settlement);
+
+        let threshold: u64 = e
+            .storage()
+            .instance()
+            .get(&DataKey::Threshold)
+            .unwrap_or(0);
+
+        Ok(ApproveResult {
+            approval_weight: settlement.approval_weight,
+            threshold,
+        })
+    }
+
+    /// Cancel a pending settlement (admin/proposer action).
+    pub fn cancel(e: Env, caller: Address, settlement_id: u64) -> Result<(), SettlementError> {
+        caller.require_auth();
+        let mut settlement: Settlement = e
+            .storage()
+            .instance()
+            .get(&DataKey::Settlement(settlement_id))
+            .ok_or(SettlementError::NotFound)?;
+        if settlement.status != SettlementStatus::Pending {
+            return Err(SettlementError::NotPending);
+        }
+        settlement.status = SettlementStatus::Cancelled;
+        e.storage()
+            .instance()
+            .set(&DataKey::Settlement(settlement_id), &settlement);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    fn setup() -> (Env, Address) {
+        let e = Env::default();
+        e.mock_all_auths();
+        let id = e.register_contract(None, SettlementContract);
+        (e, id)
+    }
+
+    #[test]
+    fn test_approve_increments_weight_and_returns_threshold() {
+        let (e, id) = setup();
+        let c = SettlementContractClient::new(&e, &id);
+        let signer = Address::generate(&e);
+        let merchant = Address::generate(&e);
+
+        c.initialize(&soroban_sdk::vec![&e, (signer.clone(), 2u64)], &3u64);
+        let sid = c.propose(&signer, &merchant, &1000u64);
+
+        let res = c.approve_settlement(&signer, &sid);
+        assert_eq!(res.approval_weight, 2);
+        assert_eq!(res.threshold, 3);
+    }
+
+    #[test]
+    fn test_approve_unauthorized_signer() {
+        let (e, id) = setup();
+        let c = SettlementContractClient::new(&e, &id);
+        let authorized = Address::generate(&e);
+        let stranger = Address::generate(&e);
+        let merchant = Address::generate(&e);
+
+        c.initialize(&soroban_sdk::vec![&e, (authorized.clone(), 1u64)], &1u64);
+        let sid = c.propose(&authorized, &merchant, &500u64);
+
+        let res = c.try_approve_settlement(&stranger, &sid);
+        assert_eq!(res, Err(Ok(SettlementError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_approve_already_approved() {
+        let (e, id) = setup();
+        let c = SettlementContractClient::new(&e, &id);
+        let signer = Address::generate(&e);
+        let merchant = Address::generate(&e);
+
+        c.initialize(&soroban_sdk::vec![&e, (signer.clone(), 1u64)], &2u64);
+        let sid = c.propose(&signer, &merchant, &100u64);
+
+        c.approve_settlement(&signer, &sid);
+        let res = c.try_approve_settlement(&signer, &sid);
+        assert_eq!(res, Err(Ok(SettlementError::AlreadyApproved)));
+    }
+
+    #[test]
+    fn test_approve_not_found() {
+        let (e, id) = setup();
+        let c = SettlementContractClient::new(&e, &id);
+        let signer = Address::generate(&e);
+
+        c.initialize(&soroban_sdk::vec![&e, (signer.clone(), 1u64)], &1u64);
+
+        let res = c.try_approve_settlement(&signer, &99u64);
+        assert_eq!(res, Err(Ok(SettlementError::NotFound)));
+    }
+
+    #[test]
+    fn test_approve_not_pending() {
+        let (e, id) = setup();
+        let c = SettlementContractClient::new(&e, &id);
+        let signer = Address::generate(&e);
+        let merchant = Address::generate(&e);
+
+        c.initialize(&soroban_sdk::vec![&e, (signer.clone(), 1u64)], &1u64);
+        let sid = c.propose(&signer, &merchant, &200u64);
+        c.cancel(&signer, &sid);
+
+        let res = c.try_approve_settlement(&signer, &sid);
+        assert_eq!(res, Err(Ok(SettlementError::NotPending)));
+    }
+
+    #[test]
+    fn test_multiple_signers_accumulate_weight() {
+        let (e, id) = setup();
+        let c = SettlementContractClient::new(&e, &id);
+        let s1 = Address::generate(&e);
+        let s2 = Address::generate(&e);
+        let merchant = Address::generate(&e);
+
+        c.initialize(
+            &soroban_sdk::vec![&e, (s1.clone(), 1u64), (s2.clone(), 2u64)],
+            &3u64,
+        );
+        let sid = c.propose(&s1, &merchant, &500u64);
+
+        let r1 = c.approve_settlement(&s1, &sid);
+        assert_eq!(r1.approval_weight, 1);
+
+        let r2 = c.approve_settlement(&s2, &sid);
+        assert_eq!(r2.approval_weight, 3);
+        assert_eq!(r2.threshold, 3);
+    }
+}


### PR DESCRIPTION
Closes #119
Closes #118
## Summary

Implements the `approve_settlement` endpoint on the `SettlementContract` Soroban contract, fulfilling the `POST /settlements/:id/approve` requirement.

## Changes

- `contracts/Cargo.toml` — new workspace file so `cargo test` in `contracts/` discovers both `invoice` and `settlement` crates
- `contracts/settlement/Cargo.toml` — new crate manifest (soroban-sdk v21, mirrors invoice crate conventions)
- `contracts/settlement/src/lib.rs` — contract implementation

## Contract interface

```rust
pub fn approve_settlement(
    e: Env,
    signer: Address,
    settlement_id: u64,
) -> Result<ApproveResult, SettlementError>
```

`ApproveResult` returns `{ approval_weight, threshold }` so callers can track progress toward execution.

## Error handling

| Error | HTTP equivalent | Condition |
|---|---|---|
| `Unauthorized` | 403 | Signer has no registered weight |
| `AlreadyApproved` | 409 | Signer already approved this settlement |
| `NotPending` | 422 | Settlement is not in Pending status |
| `NotFound` | 404 | Settlement ID does not exist |

## Tests

6 unit tests covering all error cases plus success and multi-signer weight accumulation. All run under the existing `backend-tests` CI workflow (`cargo test` in `contracts/`).