### PR TITLE
feat: implement is_allowed with time-expiry check in compliance

### DIFF
--- a/COMEBACKHERE-contracts/contracts/compliance/Cargo.toml
+++ b/COMEBACKHERE-contracts/contracts/compliance/Cargo.toml
@@ -6,8 +6,14 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+testutils = ["soroban-sdk/testutils"]
+
 [dependencies]
 soroban-sdk = "20.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "20.0.0", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/COMEBACKHERE-contracts/contracts/compliance/src/lib.rs
+++ b/COMEBACKHERE-contracts/contracts/compliance/src/lib.rs
@@ -113,3 +113,43 @@ impl ComplianceContract {
         e.storage().instance().set(&DataKey::Paused, &false);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::Env;
+
+    fn setup(ts: u64) -> (Env, ComplianceContractClient, Address, Address) {
+        let e = Env::default();
+        e.mock_all_auths();
+        let contract_id = e.register_contract(None, ComplianceContract);
+        let c = ComplianceContractClient::new(&e, &contract_id);
+        let admin = Address::generate(&e);
+        let addr = Address::generate(&e);
+        c.initialize(&admin);
+        e.ledger().set_timestamp(ts);
+        (e, c, admin, addr)
+    }
+
+    #[test]
+    fn test_is_allowed_not_expired() {
+        let (_e, c, admin, addr) = setup(1000);
+        c.allow_address_until(&admin, &addr, &2000u64);
+        assert!(c.is_allowed(&addr));
+    }
+
+    #[test]
+    fn test_is_allowed_exactly_at_expiry_returns_false() {
+        let (_e, c, admin, addr) = setup(1000);
+        c.allow_address_until(&admin, &addr, &1000u64);
+        assert!(!c.is_allowed(&addr));
+    }
+
+    #[test]
+    fn test_is_allowed_past_expiry_returns_false() {
+        let (_e, c, admin, addr) = setup(1001);
+        c.allow_address_until(&admin, &addr, &1000u64);
+        assert!(!c.is_allowed(&addr));
+    }
+}


### PR DESCRIPTION
## Summary
  
  `ComplianceContract::is_allowed` already evaluates the `AllowedUntil(until)` variant
  by comparing `env.ledger().timestamp() < until`, returning `false` when the current
  ledger time meets or exceeds the stored expiry. This PR adds the missing test coverage
  for that logic and wires up the `testutils` dev-dependency so tests can run.
  
  ## Changes
  
  - `COMEBACKHERE-contracts/contracts/compliance/src/lib.rs` — adds `#[cfg(test)]` module with three focused tests:
    - `test_is_allowed_not_expired` — address with a future expiry returns `true`
    - `test_is_allowed_exactly_at_expiry_returns_false` — boundary: `timestamp == expiry` returns `false`
    - `test_is_allowed_past_expiry_returns_false` — `timestamp > expiry` returns `false`
  - `COMEBACKHERE-contracts/contracts/compliance/Cargo.toml` — adds `[features] testutils` and `[dev-dependencies]` with
  `soroban-sdk/testutils`
  
  ## Testing
  
  ```bash
  cargo test -p comebackhere-compliance
  
  All three tests pass against the existing is_allowed implementation.
  
  Closes #105 