### PR TITLE
feat: implement dark mode support

### DIFF
--- a/comebackhere-frontend/src/App.css
+++ b/comebackhere-frontend/src/App.css
@@ -14,6 +14,7 @@
   --color-success: #16a34a;
   --color-bg: #f8fafc;
   --color-surface: #ffffff;
+  --color-surface-muted: #f1f5f9;
   --color-border: #e2e8f0;
   --color-text: #1e293b;
   --color-text-secondary: #64748b;
@@ -21,8 +22,45 @@
   --color-error-border: #fecaca;
   --color-success-bg: #f0fdf4;
   --color-success-border: #bbf7d0;
+  --color-warning-bg: #fef3c7;
+  --color-warning-text: #92400e;
+  --color-info-bg: #dbeafe;
+  --color-info-text: #1e40af;
+  --color-muted-bg: #f3f4f6;
+  --color-muted-text: #6b7280;
+  --color-purple-bg: #f3e8ff;
+  --color-purple-text: #6b21a8;
+  --color-overlay: rgba(15, 23, 42, 0.45);
   --radius: 8px;
   --shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+html[data-theme="dark"] {
+  --color-primary: #818cf8;
+  --color-primary-hover: #6366f1;
+  --color-danger: #f87171;
+  --color-danger-hover: #ef4444;
+  --color-success: #34d399;
+  --color-bg: #0f172a;
+  --color-surface: #111827;
+  --color-surface-muted: #1e293b;
+  --color-border: #334155;
+  --color-text: #f8fafc;
+  --color-text-secondary: #cbd5e1;
+  --color-error-bg: #450a0a;
+  --color-error-border: #991b1b;
+  --color-success-bg: #052e1a;
+  --color-success-border: #166534;
+  --color-warning-bg: #451a03;
+  --color-warning-text: #fcd34d;
+  --color-info-bg: #1e3a8a;
+  --color-info-text: #bfdbfe;
+  --color-muted-bg: #1f2937;
+  --color-muted-text: #d1d5db;
+  --color-purple-bg: #3b0764;
+  --color-purple-text: #e9d5ff;
+  --color-overlay: rgba(2, 6, 23, 0.72);
+  --shadow: 0 1px 3px rgba(0, 0, 0, 0.35), 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
 body {
@@ -43,12 +81,43 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
   margin-bottom: 24px;
 }
 
 .app-header h1 {
   font-size: 1.5rem;
   font-weight: 700;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 6px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.theme-toggle:hover {
+  background: var(--color-surface-muted);
+  border-color: var(--color-primary);
 }
 
 .tabs {
@@ -146,7 +215,7 @@ h3 {
 }
 
 .btn--secondary:hover:not(:disabled) {
-  background: #cbd5e1;
+  background: var(--color-surface-muted);
 }
 
 .btn--danger {
@@ -230,33 +299,33 @@ h3 {
 }
 
 .badge--pending {
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--color-warning-bg);
+  color: var(--color-warning-text);
 }
 
 .badge--paid {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--color-info-bg);
+  color: var(--color-info-text);
 }
 
 .badge--expired {
-  background: #f3f4f6;
-  color: #6b7280;
+  background: var(--color-muted-bg);
+  color: var(--color-muted-text);
 }
 
 .badge--cancelled {
-  background: #fee2e2;
-  color: #991b1b;
+  background: var(--color-error-bg);
+  color: var(--color-danger);
 }
 
 .badge--refund-requested {
-  background: #f3e8ff;
-  color: #6b21a8;
+  background: var(--color-purple-bg);
+  color: var(--color-purple-text);
 }
 
 .badge--released {
-  background: #d1fae5;
-  color: #065f46;
+  background: var(--color-success-bg);
+  color: var(--color-success);
 }
 
 .message {
@@ -387,7 +456,7 @@ h3 {
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--color-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -400,7 +469,7 @@ h3 {
   padding: 24px;
   max-width: 480px;
   width: 90%;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 20px 60px var(--color-overlay);
 }
 
 .modal h2 {
@@ -446,4 +515,12 @@ h3 {
 
 .refund-flow h2 {
   margin-bottom: 20px;
+}
+
+@media (max-width: 640px) {
+  .app-header,
+  .header-actions {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 }

--- a/comebackhere-frontend/src/App.tsx
+++ b/comebackhere-frontend/src/App.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { InvoicePayment } from "./components/InvoicePayment"
 import { RefundRequest } from "./components/RefundRequest"
 import { ComplianceManager } from "./components/ComplianceManager"
 import { useInvoice } from "./hooks/useInvoice"
+import { useTheme } from "./hooks/useTheme"
 import { useWallet } from "./hooks/useWallet"
 import "./App.css"
 
@@ -79,26 +80,38 @@ function RefundTab() {
 
 export default function App() {
   const { address, connected, connect, connecting } = useWallet()
+  const { theme, toggleTheme } = useTheme()
   const [tab, setTab] = useState<Tab>("payment")
+  const nextTheme = theme === "dark" ? "light" : "dark"
 
   return (
     <div className="app">
       <header className="app-header">
         <h1>ComebackHere</h1>
-        <div className="wallet-bar">
-          {connected ? (
-            <span className="wallet-address">
-              Connected: {address?.slice(0, 6)}...{address?.slice(-4)}
-            </span>
-          ) : (
-            <button
-              className="btn btn--primary btn--sm"
-              onClick={connect}
-              disabled={connecting}
-            >
-              {connecting ? "Connecting..." : "Connect Wallet"}
-            </button>
-          )}
+        <div className="header-actions">
+          <button
+            type="button"
+            className="theme-toggle"
+            onClick={toggleTheme}
+            aria-label={`Switch to ${nextTheme} theme`}
+          >
+            <span>{theme === "dark" ? "Light" : "Dark"}</span>
+          </button>
+          <div className="wallet-bar">
+            {connected ? (
+              <span className="wallet-address">
+                Connected: {address?.slice(0, 6)}...{address?.slice(-4)}
+              </span>
+            ) : (
+              <button
+                className="btn btn--primary btn--sm"
+                onClick={connect}
+                disabled={connecting}
+              >
+                {connecting ? "Connecting..." : "Connect Wallet"}
+              </button>
+            )}
+          </div>
         </div>
       </header>
 

--- a/comebackhere-frontend/src/components/InvoicePayment.tsx
+++ b/comebackhere-frontend/src/components/InvoicePayment.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react"
-import type { Invoice } from "../types"
 import { useInvoice } from "../hooks/useInvoice"
 import { useWallet } from "../hooks/useWallet"
 import { StatusBadge } from "./StatusBadge"

--- a/comebackhere-frontend/src/hooks/useTheme.ts
+++ b/comebackhere-frontend/src/hooks/useTheme.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react"
+
+export type Theme = "light" | "dark"
+
+const THEME_STORAGE_KEY = "comebackhere-theme"
+
+function isTheme(value: string | null): value is Theme {
+  return value === "light" || value === "dark"
+}
+
+function getStoredTheme(): Theme | null {
+  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY)
+  return isTheme(storedTheme) ? storedTheme : null
+}
+
+function getSystemTheme(): Theme {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light"
+}
+
+export function useTheme() {
+  const [hasManualPreference, setHasManualPreference] = useState(
+    () => getStoredTheme() !== null,
+  )
+  const [theme, setTheme] = useState<Theme>(() => getStoredTheme() ?? getSystemTheme())
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme
+    document.documentElement.style.colorScheme = theme
+  }, [theme])
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
+
+    const handleSystemThemeChange = (event: MediaQueryListEvent) => {
+      if (!hasManualPreference) {
+        setTheme(event.matches ? "dark" : "light")
+      }
+    }
+
+    mediaQuery.addEventListener("change", handleSystemThemeChange)
+    return () => mediaQuery.removeEventListener("change", handleSystemThemeChange)
+  }, [hasManualPreference])
+
+  const toggleTheme = () => {
+    setHasManualPreference(true)
+    setTheme((currentTheme) => {
+      const nextTheme = currentTheme === "dark" ? "light" : "dark"
+      window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme)
+      return nextTheme
+    })
+  }
+
+  return { theme, toggleTheme }
+}

--- a/comebackhere-frontend/src/utils/compliance.ts
+++ b/comebackhere-frontend/src/utils/compliance.ts
@@ -28,11 +28,15 @@ function getServer() {
   return new SorobanRpc.Server(SOROBAN_RPC)
 }
 
+function u64ToNumber(value: xdr.Uint64 | undefined): number {
+  return Number(value?.toString() ?? 0)
+}
+
 function parseAddressStatus(scVal: xdr.ScVal): ComplianceStatusResult {
   const vec = scVal.vec()
   const variant = vec?.[0]?.sym()?.toString() ?? "Cleared"
   if (variant === "AllowedUntil") {
-    const until = vec?.[1]?.u64()?.toNumber() ?? 0
+    const until = u64ToNumber(vec?.[1]?.u64())
     return { status: variant as ComplianceStatus, expiresAt: until }
   }
   return { status: variant as ComplianceStatus, expiresAt: null }

--- a/comebackhere-frontend/src/utils/soroban.ts
+++ b/comebackhere-frontend/src/utils/soroban.ts
@@ -20,8 +20,16 @@ function getServer() {
   return new SorobanRpc.Server(SOROBAN_RPC)
 }
 
+function u64ToNumber(value: xdr.Uint64 | undefined): number {
+  return Number(value?.toString() ?? 0)
+}
+
 function scValToInvoice(scVal: xdr.ScVal): Invoice {
   const map = scVal.map()
+  if (!map) {
+    throw new Error("Invalid invoice response")
+  }
+
   const entries: Record<string, xdr.ScVal> = {}
   for (const entry of map) {
     const key = entry.key().sym().toString()
@@ -34,9 +42,9 @@ function scValToInvoice(scVal: xdr.ScVal): Invoice {
     payer: entries.payer?.address()?.toString() ?? "",
     amount_usdc: entries.amount_usdc?.i128()?.toString() ?? "0",
     gross_usdc: entries.gross_usdc?.i128()?.toString() ?? "0",
-    expires_at: entries.expires_at?.u64()?.toNumber() ?? 0,
+    expires_at: u64ToNumber(entries.expires_at?.u64()),
     status: scValToInvoiceStatus(entries.status),
-    paid_at: entries.paid_at?.u64()?.toNumber() ?? null,
+    paid_at: entries.paid_at?.u64() ? u64ToNumber(entries.paid_at.u64()) : null,
     metadata_hash: entries.metadata_hash?.bytes()?.toString() ?? null,
     payment_link_hash: entries.payment_link_hash?.bytes()?.toString() ?? null,
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import SettlementProposalForm from "./components/SettlementProposal/SettlementPr
 import DisputeVotingPanel from "./components/DisputeVoting/DisputeVotingPanel";
 import SignerManagement from "./components/SignerManagement/SignerManagement";
 import ABIExplorer from "./components/ABIExplorer";
+import { ThemeProvider, useTheme } from "./theme";
 
 function InvoicesPage() {
   return <p>Invoices list will appear here.</p>;
@@ -22,10 +23,30 @@ function SignersPage() {
 }
 
 function SettingsPage() {
-  return <p>Settings will appear here.</p>;
+  const { theme, toggleTheme } = useTheme();
+  const nextTheme = theme === "dark" ? "light" : "dark";
+
+  return (
+    <section className="settings-panel">
+      <div>
+        <h3 className="settings-panel__title">Appearance</h3>
+        <p className="settings-panel__description">
+          Current theme: {theme}. Your choice is remembered on this device.
+        </p>
+      </div>
+      <button
+        type="button"
+        className="theme-toggle theme-toggle--wide"
+        onClick={toggleTheme}
+        aria-label={`Switch to ${nextTheme} theme`}
+      >
+        <span>Use {nextTheme} theme</span>
+      </button>
+    </section>
+  );
 }
 
-export default function App() {
+function AppRoutes() {
   return (
     <Routes>
       <Route element={<DashboardLayout />}>
@@ -38,5 +59,13 @@ export default function App() {
         <Route path="abi" element={<ABIExplorer />} />
       </Route>
     </Routes>
+  );
+}
+
+export default function App() {
+  return (
+    <ThemeProvider>
+      <AppRoutes />
+    </ThemeProvider>
   );
 }

--- a/frontend/src/components/Dashboard/DashboardLayout.css
+++ b/frontend/src/components/Dashboard/DashboardLayout.css
@@ -1,6 +1,7 @@
 .dashboard {
   display: flex;
   min-height: 100vh;
+  background: var(--color-bg);
 }
 
 .dashboard-main {
@@ -11,6 +12,10 @@
 }
 
 .dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
   margin-bottom: 28px;
 }
 
@@ -31,6 +36,55 @@
   flex: 1;
 }
 
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 36px;
+  padding: 8px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-card-bg);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  font-weight: 600;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.theme-toggle:hover {
+  background: var(--color-input-bg);
+  border-color: var(--color-primary);
+}
+
+.theme-toggle--wide {
+  align-self: flex-start;
+}
+
+.settings-panel {
+  max-width: 560px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 24px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-card-bg);
+  box-shadow: var(--shadow);
+}
+
+.settings-panel__title {
+  margin-bottom: 6px;
+  color: var(--color-text);
+  font-size: 1.1rem;
+}
+
+.settings-panel__description {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
 @media (max-width: 768px) {
   .dashboard {
     flex-direction: column;
@@ -39,6 +93,12 @@
   .dashboard-main {
     margin-left: 0;
     padding: 20px 16px;
+  }
+
+  .dashboard-header,
+  .settings-panel {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .stats-grid {

--- a/frontend/src/components/Dashboard/DashboardLayout.tsx
+++ b/frontend/src/components/Dashboard/DashboardLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from "react-router-dom";
 import Sidebar from "./Sidebar";
 import StatsCard from "./StatsCard";
+import { useTheme } from "../../theme";
 import "./DashboardLayout.css";
 
 const stats = [
@@ -10,12 +11,23 @@ const stats = [
 ];
 
 export default function DashboardLayout() {
+  const { theme, toggleTheme } = useTheme();
+  const nextTheme = theme === "dark" ? "light" : "dark";
+
   return (
     <div className="dashboard">
       <Sidebar />
       <main className="dashboard-main">
         <header className="dashboard-header">
           <h2 className="dashboard-heading">Overview</h2>
+          <button
+            type="button"
+            className="theme-toggle"
+            onClick={toggleTheme}
+            aria-label={`Switch to ${nextTheme} theme`}
+          >
+            <span>{theme === "dark" ? "Light" : "Dark"}</span>
+          </button>
         </header>
         <section className="stats-grid">
           {stats.map((stat) => (

--- a/frontend/src/components/DisputeVoting/DisputeVotingPanel.css
+++ b/frontend/src/components/DisputeVoting/DisputeVotingPanel.css
@@ -118,13 +118,13 @@
 }
 
 .outcome-badge--claimant {
-  background: #dcfce7;
-  color: #15803d;
+  background: var(--color-success-soft-bg);
+  color: var(--color-success-soft-text);
 }
 
 .outcome-badge--counterparty {
-  background: #fee2e2;
-  color: #b91c1c;
+  background: var(--color-danger-soft-bg);
+  color: var(--color-danger-soft-text);
 }
 
 .resolution-bar-wrap {
@@ -136,7 +136,7 @@
 .resolution-bar {
   width: 120px;
   height: 8px;
-  background: #e5e7eb;
+  background: var(--color-progress-bg);
   border-radius: 4px;
   overflow: hidden;
 }

--- a/frontend/src/components/SettlementApproval.tsx
+++ b/frontend/src/components/SettlementApproval.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useSettlements } from '../hooks/useSettlements'
-import { SignerInfo } from '../types'
+import { useTheme } from '../theme'
+import { Settlement, SignerInfo } from '../types'
 
 const SIGNERS: SignerInfo[] = [
   { address: import.meta.env.VITE_SIGNER_1 ?? '', weight: 1 },
@@ -23,8 +24,10 @@ function formatAmount(raw: string): string {
 
 export function SettlementApproval() {
   const { settlements, loading, error, approveSettlement } = useSettlements()
+  const { theme, toggleTheme } = useTheme()
   const [approving, setApproving] = useState<Record<string, boolean>>({})
   const [actionError, setActionError] = useState<string | null>(null)
+  const nextTheme = theme === 'dark' ? 'light' : 'dark'
 
   const handleApprove = async (settlementId: number, signer: string) => {
     const key = `${settlementId}-${signer}`
@@ -49,14 +52,24 @@ export function SettlementApproval() {
   }
 
   if (error && settlements.length === 0) {
-    return <div style={styles.container}><p style={{ color: 'red' }}>Error: {error}</p></div>
+    return <div style={styles.container}><p style={styles.errorText}>Error: {error}</p></div>
   }
 
   return (
     <div style={styles.container}>
-      <h1 style={styles.title}>Settlement Approvals</h1>
+      <header style={styles.header}>
+        <h1 style={styles.title}>Settlement Approvals</h1>
+        <button
+          type="button"
+          style={styles.themeToggle}
+          onClick={toggleTheme}
+          aria-label={`Switch to ${nextTheme} theme`}
+        >
+          {theme === 'dark' ? 'Light' : 'Dark'} theme
+        </button>
+      </header>
 
-      {actionError && <p style={{ color: 'red' }}>{actionError}</p>}
+      {actionError && <p style={styles.errorText}>{actionError}</p>}
 
       {pendingSettlements.length === 0 ? (
         <p>No pending settlements.</p>
@@ -95,7 +108,8 @@ export function SettlementApproval() {
             style={{
               ...styles.progressFill,
               width: `${Math.min(100, (current / required) * 100)}%`,
-              background: current >= required ? '#22c55e' : '#3b82f6',
+              background:
+                current >= required ? 'var(--color-success)' : 'var(--color-primary)',
             }}
           />
         </div>
@@ -147,28 +161,52 @@ const styles: Record<string, React.CSSProperties> = {
     margin: '0 auto',
     padding: '2rem 1rem',
     fontFamily: 'system-ui, sans-serif',
+    color: 'var(--color-text)',
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 16,
+    flexWrap: 'wrap',
+    marginBottom: '1.5rem',
   },
   title: {
     fontSize: '1.5rem',
     fontWeight: 600,
-    marginBottom: '1.5rem',
+    marginBottom: 0,
+  },
+  themeToggle: {
+    padding: '0.5rem 0.75rem',
+    border: '1px solid var(--color-border)',
+    borderRadius: 8,
+    background: 'var(--color-card-bg)',
+    color: 'var(--color-text)',
+    fontSize: '0.875rem',
+    fontWeight: 600,
+    cursor: 'pointer',
   },
   table: {
     width: '100%',
     borderCollapse: 'collapse',
+    background: 'var(--color-card-bg)',
+    boxShadow: 'var(--shadow)',
   },
   th: {
     textAlign: 'left',
     padding: '0.5rem',
-    borderBottom: '2px solid #e5e7eb',
+    borderBottom: '2px solid var(--color-border)',
     fontWeight: 600,
     fontSize: '0.875rem',
-    color: '#374151',
+    color: 'var(--color-text-muted)',
   },
   td: {
     padding: '0.5rem',
-    borderBottom: '1px solid #e5e7eb',
+    borderBottom: '1px solid var(--color-border)',
     fontSize: '0.875rem',
+  },
+  errorText: {
+    color: 'var(--color-danger)',
   },
   progressWrap: {
     display: 'flex',
@@ -178,7 +216,7 @@ const styles: Record<string, React.CSSProperties> = {
   progressBar: {
     width: 80,
     height: 8,
-    background: '#e5e7eb',
+    background: 'var(--color-progress-bg)',
     borderRadius: 4,
     overflow: 'hidden',
   },
@@ -189,15 +227,15 @@ const styles: Record<string, React.CSSProperties> = {
   },
   progressText: {
     fontSize: '0.75rem',
-    color: '#6b7280',
+    color: 'var(--color-text-muted)',
     whiteSpace: 'nowrap',
   },
   approveBtn: {
     padding: '4px 8px',
     fontSize: '0.75rem',
-    border: '1px solid #3b82f6',
+    border: '1px solid var(--color-primary)',
     borderRadius: 4,
-    background: '#3b82f6',
+    background: 'var(--color-primary)',
     color: '#fff',
     cursor: 'pointer',
   },

--- a/frontend/src/components/SignerManagement/SignerManagement.css
+++ b/frontend/src/components/SignerManagement/SignerManagement.css
@@ -81,8 +81,8 @@
 .weight-badge {
   display: inline-block;
   padding: 2px 10px;
-  background: #e0e7ff;
-  color: #3730a3;
+  background: var(--color-info-soft-bg);
+  color: var(--color-info-soft-text);
   border-radius: 999px;
   font-size: 0.78rem;
   font-weight: 700;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,6 +24,13 @@
   --color-border: #e5e7eb;
   --color-input-bg: #ffffff;
   --color-input-border: #d1d5db;
+  --color-success-soft-bg: #dcfce7;
+  --color-success-soft-text: #15803d;
+  --color-danger-soft-bg: #fee2e2;
+  --color-danger-soft-text: #b91c1c;
+  --color-info-soft-bg: #e0e7ff;
+  --color-info-soft-text: #3730a3;
+  --color-progress-bg: #e5e7eb;
   --radius: 8px;
   --shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.06);
   --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.1);
@@ -34,6 +41,40 @@
   font-size: 16px;
   line-height: 1.5;
   color: var(--color-text);
+  background: var(--color-bg);
+}
+
+html[data-theme="dark"] {
+  --color-bg: #0f172a;
+  --color-sidebar-bg: #020617;
+  --color-sidebar-text: #94a3b8;
+  --color-sidebar-active: #f8fafc;
+  --color-sidebar-hover-bg: #1e293b;
+  --color-sidebar-active-bg: #334155;
+  --color-card-bg: #111827;
+  --color-primary: #818cf8;
+  --color-primary-hover: #6366f1;
+  --color-danger: #f87171;
+  --color-warning: #fbbf24;
+  --color-success: #34d399;
+  --color-text: #f8fafc;
+  --color-text-muted: #cbd5e1;
+  --color-border: #334155;
+  --color-input-bg: #0f172a;
+  --color-input-border: #475569;
+  --color-success-soft-bg: #052e1a;
+  --color-success-soft-text: #86efac;
+  --color-danger-soft-bg: #450a0a;
+  --color-danger-soft-text: #fecaca;
+  --color-info-soft-bg: #1e1b4b;
+  --color-info-soft-text: #c7d2fe;
+  --color-progress-bg: #334155;
+  --shadow: 0 1px 3px rgba(0, 0, 0, 0.35), 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+body {
+  min-height: 100vh;
   background: var(--color-bg);
 }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,14 +2,18 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { SettlementApproval } from './components/SettlementApproval'
+import { ThemeProvider } from './theme'
+import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/settlements" element={<SettlementApproval />} />
-        <Route path="*" element={<Navigate to="/settlements" replace />} />
-      </Routes>
-    </BrowserRouter>
+    <ThemeProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/settlements" element={<SettlementApproval />} />
+          <Route path="*" element={<Navigate to="/settlements" replace />} />
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
   </React.StrictMode>,
 )

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -1,0 +1,84 @@
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+export type Theme = "light" | "dark";
+
+const THEME_STORAGE_KEY = "comebackhere-theme";
+
+type ThemeContextValue = {
+  theme: Theme;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function isTheme(value: string | null): value is Theme {
+  return value === "light" || value === "dark";
+}
+
+function getStoredTheme(): Theme | null {
+  if (typeof window === "undefined") return null;
+
+  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+  return isTheme(storedTheme) ? storedTheme : null;
+}
+
+function getSystemTheme(): Theme {
+  if (typeof window === "undefined") return "light";
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [hasManualPreference, setHasManualPreference] = useState(
+    () => getStoredTheme() !== null,
+  );
+  const [theme, setTheme] = useState<Theme>(() => getStoredTheme() ?? getSystemTheme());
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.style.colorScheme = theme;
+  }, [theme]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    const handleSystemThemeChange = (event: MediaQueryListEvent) => {
+      if (!hasManualPreference) {
+        setTheme(event.matches ? "dark" : "light");
+      }
+    };
+
+    mediaQuery.addEventListener("change", handleSystemThemeChange);
+    return () => mediaQuery.removeEventListener("change", handleSystemThemeChange);
+  }, [hasManualPreference]);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      toggleTheme: () => {
+        setHasManualPreference(true);
+        setTheme((currentTheme) => {
+          const nextTheme = currentTheme === "dark" ? "light" : "dark";
+          window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+          return nextTheme;
+        });
+      },
+    }),
+    [theme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error("useTheme must be used within ThemeProvider");
+  }
+
+  return context;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- Add persisted light/dark theme support using the shared localStorage key `comebackhere-theme`.
- Respect `prefers-color-scheme` on first load and keep following system changes until the user manually toggles the theme.
- Add theme toggles to the dashboard/header surfaces and update UI color tokens so components render correctly in both themes.
- Replace remaining hardcoded status/progress colors with theme-aware tokens and fix small TypeScript issues surfaced by production builds.

## Testing
- `npm run build` in `frontend`
- `npm run build` in `comebackhere-frontend`

Closes #76