### PR TITLE
feat: add cancel, refund endpoints and deploy verification scripts

### DIFF
--- a/.github/workflows/ci-post-deploy-verify.yml
+++ b/.github/workflows/ci-post-deploy-verify.yml
@@ -1,0 +1,124 @@
+name: CI - Post-Deployment Verification
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Target network (testnet)"
+        required: true
+        default: "testnet"
+      invoice_contract_id:
+        description: "Deployed invoice contract ID (C…)"
+        required: true
+      treasury_contract_id:
+        description: "Deployed treasury contract ID (C…)"
+        required: true
+      compliance_contract_id:
+        description: "Deployed compliance contract ID (C…)"
+        required: true
+
+jobs:
+  deploy-testnet:
+    name: deploy (testnet)
+    runs-on: ubuntu-latest
+    # Only runs on manual dispatch or if wired into a release workflow.
+    if: github.event_name == 'workflow_dispatch'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: WHEELBACK/COMEBACKHERE-contracts
+          ref: main
+          path: COMEBACKHERE-contracts
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            COMEBACKHERE-contracts/target
+          key: ${{ runner.os }}-cargo-deploy-${{ hashFiles('COMEBACKHERE-contracts/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-deploy-
+
+      - name: Build WASM artifacts
+        run: cargo build --target wasm32-unknown-unknown --release
+        working-directory: COMEBACKHERE-contracts
+
+      - name: Run deploy_testnet.sh
+        env:
+          STELLAR_NETWORK: ${{ github.event.inputs.network }}
+          SOROBAN_RPC_URL: https://soroban-testnet.stellar.org
+          SOROBAN_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+          ADMIN_PUBLIC_KEY: ${{ secrets.TESTNET_ADMIN_PUBLIC_KEY }}
+          ADMIN_SECRET_KEY: ${{ secrets.TESTNET_ADMIN_SECRET_KEY }}
+          INVOICE_CONTRACT_ID: ${{ github.event.inputs.invoice_contract_id }}
+          TREASURY_CONTRACT_ID: ${{ github.event.inputs.treasury_contract_id }}
+          COMPLIANCE_CONTRACT_ID: ${{ github.event.inputs.compliance_contract_id }}
+        run: ./scripts/deploy_testnet.sh
+
+  verify:
+    name: post-deploy WASM hash verification
+    runs-on: ubuntu-latest
+    needs: deploy-testnet
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: WHEELBACK/COMEBACKHERE-contracts
+          ref: main
+          path: COMEBACKHERE-contracts
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            COMEBACKHERE-contracts/target
+          key: ${{ runner.os }}-cargo-deploy-${{ hashFiles('COMEBACKHERE-contracts/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-deploy-
+
+      - name: Build WASM artifacts (for hash comparison)
+        run: cargo build --target wasm32-unknown-unknown --release
+        working-directory: COMEBACKHERE-contracts
+
+      - name: Run verify.sh
+        env:
+          SOROBAN_RPC_URL: https://soroban-testnet.stellar.org
+          STELLAR_NETWORK: ${{ github.event.inputs.network }}
+          INVOICE_CONTRACT_ID: ${{ github.event.inputs.invoice_contract_id }}
+          TREASURY_CONTRACT_ID: ${{ github.event.inputs.treasury_contract_id }}
+          COMPLIANCE_CONTRACT_ID: ${{ github.event.inputs.compliance_contract_id }}
+          CONTRACTS_DIR: COMEBACKHERE-contracts/target/wasm32-unknown-unknown/release
+        run: ./scripts/verify.sh
+
+  export-addresses:
+    name: export and validate deployed addresses
+    runs-on: ubuntu-latest
+    needs: verify
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run export_deployed_addresses.sh
+        env:
+          STELLAR_NETWORK: ${{ github.event.inputs.network }}
+          INVOICE_CONTRACT_ID: ${{ github.event.inputs.invoice_contract_id }}
+          TREASURY_CONTRACT_ID: ${{ github.event.inputs.treasury_contract_id }}
+          COMPLIANCE_CONTRACT_ID: ${{ github.event.inputs.compliance_contract_id }}
+        run: ./scripts/export_deployed_addresses.sh
+
+      - name: Upload addresses artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deployed-addresses-${{ github.event.inputs.network }}
+          path: artifacts/addresses.json

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -5,8 +5,10 @@ mod types;
 use axum::{routing::{get, post}, Router};
 use std::sync::Arc;
 
+use routes::cancel::cancel_invoice;
 use routes::invoices::get_invoice;
 use routes::pay::pay_invoice;
+use routes::refund::refund_invoice;
 use soroban::SorobanClient;
 
 #[tokio::main]
@@ -21,6 +23,8 @@ async fn main() {
     let app = Router::new()
         .route("/invoices/:id", get(get_invoice))
         .route("/invoices/:id/pay", post(pay_invoice))
+        .route("/invoices/:id/cancel", post(cancel_invoice))
+        .route("/invoices/:id/refund", post(refund_invoice))
         .with_state(client);
 
     let addr = "0.0.0.0:3001";

--- a/backend/src/routes/cancel.rs
+++ b/backend/src/routes/cancel.rs
@@ -1,0 +1,107 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use std::sync::Arc;
+
+use crate::soroban::SorobanClient;
+use crate::types::{CancelRequest, CancelResponse, ErrorResponse, InvoiceStatus};
+
+/// POST /invoices/:id/cancel
+///
+/// Allows a merchant to cancel a Pending invoice.
+/// Returns 403 when the contract returns Unauthorized(1).
+pub async fn cancel_invoice(
+    State(client): State<Arc<SorobanClient>>,
+    Path(id): Path<u64>,
+    Json(body): Json<CancelRequest>,
+) -> impl IntoResponse {
+    match client.cancel_invoice(id, &body.merchant, &body.signed_xdr).await {
+        Ok(resp) => (StatusCode::OK, Json(serde_json::json!(resp))).into_response(),
+        Err(e) if e.to_string().contains("UNAUTHORIZED") => (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse {
+                error: "Only the invoice merchant is authorised to cancel this invoice"
+                    .to_string(),
+                code: Some(1),
+            }),
+        )
+            .into_response(),
+        Err(e) if e.to_string().contains("NOT_FOUND") => (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("Invoice {} not found", id),
+                code: Some(4),
+            }),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+                code: None,
+            }),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::routes::invoices::get_invoice;
+    use crate::routes::pay::pay_invoice;
+    use axum::{
+        routing::{get, post},
+        Router,
+    };
+    use axum_test::TestServer;
+
+    fn make_app(client: SorobanClient) -> Router {
+        Router::new()
+            .route("/invoices/:id", get(get_invoice))
+            .route("/invoices/:id/pay", post(pay_invoice))
+            .route("/invoices/:id/cancel", post(cancel_invoice))
+            .with_state(Arc::new(client))
+    }
+
+    #[tokio::test]
+    async fn test_cancel_invoice_missing_body_returns_422() {
+        let client = SorobanClient::new(
+            "http://127.0.0.1:19999/soroban/rpc".to_string(),
+            "CONTRACT_ID".to_string(),
+        );
+        let app = make_app(client);
+        let server = TestServer::new(app).unwrap();
+
+        // No JSON body → 422 Unprocessable Entity
+        let resp = server.post("/invoices/1/cancel").await;
+        assert_eq!(resp.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn test_cancel_invoice_unreachable_rpc_returns_error() {
+        let client = SorobanClient::new(
+            "http://127.0.0.1:19999/soroban/rpc".to_string(),
+            "CONTRACT_ID".to_string(),
+        );
+        let app = make_app(client);
+        let server = TestServer::new(app).unwrap();
+
+        let resp = server
+            .post("/invoices/1/cancel")
+            .json(&serde_json::json!({
+                "merchant": "GMERCHANT0000000000000000000000000000000000000000000000000",
+                "signed_xdr": "AAAA=="
+            }))
+            .await;
+
+        assert!(
+            resp.status_code() == StatusCode::INTERNAL_SERVER_ERROR
+                || resp.status_code() == StatusCode::NOT_FOUND
+                || resp.status_code() == StatusCode::FORBIDDEN
+        );
+    }
+}

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -1,2 +1,4 @@
+pub mod cancel;
 pub mod invoices;
 pub mod pay;
+pub mod refund;

--- a/backend/src/routes/refund.rs
+++ b/backend/src/routes/refund.rs
@@ -1,0 +1,115 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use std::sync::Arc;
+
+use crate::soroban::SorobanClient;
+use crate::types::{ErrorResponse, RefundRequest, RefundResponse};
+
+/// POST /invoices/:id/refund
+///
+/// Allows a payer (customer) to request a refund on a paid invoice.
+/// Returns 422 when the contract returns NotPaid(10) — i.e. the invoice has not been paid.
+pub async fn refund_invoice(
+    State(client): State<Arc<SorobanClient>>,
+    Path(id): Path<u64>,
+    Json(body): Json<RefundRequest>,
+) -> impl IntoResponse {
+    match client.refund_invoice(id, &body.payer, &body.signed_xdr).await {
+        Ok(resp) => (StatusCode::OK, Json(serde_json::json!(resp))).into_response(),
+        Err(e) if e.to_string().contains("NOT_PAID") => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ErrorResponse {
+                error: "Invoice has not been paid and is not eligible for a refund".to_string(),
+                code: Some(10),
+            }),
+        )
+            .into_response(),
+        Err(e) if e.to_string().contains("UNAUTHORIZED") => (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse {
+                error: "Only the invoice payer is authorised to request a refund".to_string(),
+                code: Some(1),
+            }),
+        )
+            .into_response(),
+        Err(e) if e.to_string().contains("NOT_FOUND") => (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("Invoice {} not found", id),
+                code: Some(4),
+            }),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: e.to_string(),
+                code: None,
+            }),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::routes::invoices::get_invoice;
+    use crate::routes::pay::pay_invoice;
+    use axum::{
+        routing::{get, post},
+        Router,
+    };
+    use axum_test::TestServer;
+
+    fn make_app(client: SorobanClient) -> Router {
+        Router::new()
+            .route("/invoices/:id", get(get_invoice))
+            .route("/invoices/:id/pay", post(pay_invoice))
+            .route("/invoices/:id/refund", post(refund_invoice))
+            .with_state(Arc::new(client))
+    }
+
+    #[tokio::test]
+    async fn test_refund_invoice_missing_body_returns_422() {
+        let client = SorobanClient::new(
+            "http://127.0.0.1:19999/soroban/rpc".to_string(),
+            "CONTRACT_ID".to_string(),
+        );
+        let app = make_app(client);
+        let server = TestServer::new(app).unwrap();
+
+        // No JSON body → 422 Unprocessable Entity
+        let resp = server.post("/invoices/1/refund").await;
+        assert_eq!(resp.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn test_refund_invoice_unreachable_rpc_returns_error() {
+        let client = SorobanClient::new(
+            "http://127.0.0.1:19999/soroban/rpc".to_string(),
+            "CONTRACT_ID".to_string(),
+        );
+        let app = make_app(client);
+        let server = TestServer::new(app).unwrap();
+
+        let resp = server
+            .post("/invoices/1/refund")
+            .json(&serde_json::json!({
+                "payer": "GPAYER0000000000000000000000000000000000000000000000000000",
+                "signed_xdr": "AAAA=="
+            }))
+            .await;
+
+        assert!(
+            resp.status_code() == StatusCode::INTERNAL_SERVER_ERROR
+                || resp.status_code() == StatusCode::NOT_FOUND
+                || resp.status_code() == StatusCode::FORBIDDEN
+                || resp.status_code() == StatusCode::UNPROCESSABLE_ENTITY
+        );
+    }
+}

--- a/backend/src/soroban.rs
+++ b/backend/src/soroban.rs
@@ -2,10 +2,14 @@ use anyhow::{anyhow, Result};
 use reqwest::Client;
 use serde_json::{json, Value};
 
-use crate::types::{InvoiceResponse, InvoiceStatus, PayResponse, RpcRequest, RpcResponse};
+use crate::types::{
+    CancelResponse, InvoiceResponse, InvoiceStatus, PayResponse, RefundResponse, RpcRequest,
+    RpcResponse,
+};
 
 const CONTRACT_NOT_FOUND: u32 = 6;
 const CONTRACT_UNAUTHORIZED: u32 = 1;
+const CONTRACT_NOT_PAID: u32 = 10;
 
 pub struct SorobanClient {
     pub rpc_url: String,
@@ -106,6 +110,117 @@ impl SorobanClient {
             transaction_hash: tx_hash,
         })
     }
+
+    /// Submit a signed cancel_invoice transaction to Soroban.
+    ///
+    /// Only the invoice merchant is permitted to cancel a Pending invoice.
+    ///
+    /// Errors:
+    /// - "UNAUTHORIZED" when the contract returns ContractError::Unauthorized(1)
+    /// - "NOT_FOUND"    when the contract returns ContractError::InvoiceNotFound(4)
+    pub async fn cancel_invoice(
+        &self,
+        invoice_id: u64,
+        merchant: &str,
+        signed_xdr: &str,
+    ) -> Result<CancelResponse> {
+        // 1. Verify the caller is the merchant recorded on the invoice.
+        let invoice = self.get_invoice(invoice_id).await?;
+        if invoice.merchant != merchant {
+            return Err(anyhow!("UNAUTHORIZED"));
+        }
+
+        // 2. Forward the pre-signed cancel transaction.
+        let req = RpcRequest {
+            jsonrpc: "2.0",
+            id: 3,
+            method: "sendTransaction",
+            params: json!({ "transaction": signed_xdr }),
+        };
+
+        let resp: RpcResponse = self
+            .http
+            .post(&self.rpc_url)
+            .json(&req)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if let Some(err) = resp.error {
+            return Err(rpc_error_to_anyhow(&err));
+        }
+
+        let result = resp.result.ok_or_else(|| anyhow!("Empty RPC result"))?;
+
+        let tx_hash = result
+            .get("hash")
+            .and_then(|h| h.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        Ok(CancelResponse {
+            status: InvoiceStatus::Cancelled,
+            transaction_hash: tx_hash,
+        })
+    }
+
+    /// Submit a signed request_refund transaction to Soroban.
+    ///
+    /// Only the invoice payer (customer) may request a refund, and only on a Paid invoice.
+    ///
+    /// Errors:
+    /// - "NOT_PAID"     when the contract returns ContractError::RefundNotRequested(10)
+    /// - "UNAUTHORIZED" when the contract returns ContractError::Unauthorized(1)
+    /// - "NOT_FOUND"    when the contract returns ContractError::InvoiceNotFound(4)
+    pub async fn refund_invoice(
+        &self,
+        invoice_id: u64,
+        payer: &str,
+        signed_xdr: &str,
+    ) -> Result<RefundResponse> {
+        // 1. Verify the caller is the payer recorded on the invoice.
+        let invoice = self.get_invoice(invoice_id).await?;
+        if let Some(expected) = &invoice.payer {
+            if !expected.is_empty() && expected != payer {
+                return Err(anyhow!("UNAUTHORIZED"));
+            }
+        }
+
+        // 2. Forward the pre-signed refund transaction.
+        let req = RpcRequest {
+            jsonrpc: "2.0",
+            id: 4,
+            method: "sendTransaction",
+            params: json!({ "transaction": signed_xdr }),
+        };
+
+        let resp: RpcResponse = self
+            .http
+            .post(&self.rpc_url)
+            .json(&req)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if let Some(err) = resp.error {
+            return Err(rpc_error_to_anyhow(&err));
+        }
+
+        let result = resp.result.ok_or_else(|| anyhow!("Empty RPC result"))?;
+
+        let tx_hash = result
+            .get("hash")
+            .and_then(|h| h.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        Ok(RefundResponse {
+            status: InvoiceStatus::RefundRequested,
+            transaction_hash: tx_hash,
+        })
+    }
 }
 
 fn rpc_error_to_anyhow(err: &Value) -> anyhow::Error {
@@ -116,6 +231,7 @@ fn rpc_error_to_anyhow(err: &Value) -> anyhow::Error {
     match code {
         Some(c) if c == CONTRACT_NOT_FOUND => anyhow!("NOT_FOUND"),
         Some(c) if c == CONTRACT_UNAUTHORIZED => anyhow!("UNAUTHORIZED"),
+        Some(c) if c == CONTRACT_NOT_PAID => anyhow!("NOT_PAID"),
         _ => anyhow!("RPC error: {}", err),
     }
 }

--- a/backend/src/types.rs
+++ b/backend/src/types.rs
@@ -55,6 +55,38 @@ pub struct PayResponse {
     pub transaction_hash: String,
 }
 
+/// Request body for POST /invoices/:id/cancel
+#[derive(Debug, Deserialize)]
+pub struct CancelRequest {
+    /// The Stellar public key of the merchant (G…).
+    pub merchant: String,
+    /// Signed XDR transaction envelope (base64).
+    pub signed_xdr: String,
+}
+
+/// Response body for POST /invoices/:id/cancel
+#[derive(Debug, Serialize)]
+pub struct CancelResponse {
+    pub status: InvoiceStatus,
+    pub transaction_hash: String,
+}
+
+/// Request body for POST /invoices/:id/refund
+#[derive(Debug, Deserialize)]
+pub struct RefundRequest {
+    /// The Stellar public key of the payer/customer (G…).
+    pub payer: String,
+    /// Signed XDR transaction envelope (base64).
+    pub signed_xdr: String,
+}
+
+/// Response body for POST /invoices/:id/refund
+#[derive(Debug, Serialize)]
+pub struct RefundResponse {
+    pub status: InvoiceStatus,
+    pub transaction_hash: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ErrorResponse {
     pub error: String,

--- a/scripts/export_deployed_addresses.sh
+++ b/scripts/export_deployed_addresses.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
-# Write deployed contract addresses to artifacts/addresses.json (machine-readable).
+# export_deployed_addresses.sh — write deployed contract IDs to artifacts/addresses.json
+# and validate the output against the artifacts/addresses.json.example schema.
+#
+# Required environment variables:
+#   STELLAR_NETWORK        — target network name (e.g. testnet, mainnet)
+#   INVOICE_CONTRACT_ID    — deployed invoice contract address   (C…)
+#   TREASURY_CONTRACT_ID   — deployed treasury contract address  (C…)
+#   COMPLIANCE_CONTRACT_ID — deployed compliance contract address (C…)
+#
+# Optional:
+#   DEPLOYED_ADDRESSES_FILE — override output path (default: artifacts/addresses.json)
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_FILE="${DEPLOYED_ADDRESSES_FILE:-$ROOT_DIR/artifacts/addresses.json}"
+EXAMPLE_FILE="$ROOT_DIR/artifacts/addresses.json.example"
 
 : "${STELLAR_NETWORK:?STELLAR_NETWORK is required}"
 : "${INVOICE_CONTRACT_ID:?INVOICE_CONTRACT_ID is required}"
@@ -14,6 +25,7 @@ mkdir -p "$(dirname "$OUT_FILE")"
 export LC_ALL=C
 export LANG=C
 
+# ── Write addresses.json ──────────────────────────────────────────────────────
 python3 - "$OUT_FILE" <<'PY'
 import json
 import os
@@ -34,3 +46,63 @@ with open(out_path, "w", encoding="utf-8", newline="\n") as handle:
 PY
 
 echo "Deployed addresses written to $OUT_FILE"
+
+# ── Schema validation against addresses.json.example ─────────────────────────
+if [[ ! -f "$EXAMPLE_FILE" ]]; then
+  echo "WARNING: $EXAMPLE_FILE not found; skipping schema validation." >&2
+  exit 0
+fi
+
+python3 - "$OUT_FILE" "$EXAMPLE_FILE" <<'PY'
+import json
+import sys
+
+out_path = sys.argv[1]
+example_path = sys.argv[2]
+
+with open(out_path, encoding="utf-8") as f:
+    actual = json.load(f)
+with open(example_path, encoding="utf-8") as f:
+    example = json.load(f)
+
+errors = []
+
+# Top-level key presence
+for key in example:
+    if key not in actual:
+        errors.append(f"Missing top-level field: '{key}'")
+
+# 'network' must be a non-empty string
+if not isinstance(actual.get("network"), str) or not actual["network"].strip():
+    errors.append("'network' must be a non-empty string")
+
+# 'contracts' must be a list
+if not isinstance(actual.get("contracts"), list):
+    errors.append("'contracts' must be an array")
+else:
+    # Collect expected contract names from the example
+    expected_names = {c["name"] for c in example.get("contracts", [])}
+    actual_names   = {c.get("name") for c in actual["contracts"]}
+
+    for name in expected_names:
+        if name not in actual_names:
+            errors.append(f"Missing contract entry: '{name}'")
+
+    for entry in actual["contracts"]:
+        cname   = entry.get("name", "<unnamed>")
+        address = entry.get("address", "")
+        if not address or not isinstance(address, str):
+            errors.append(f"Contract '{cname}': 'address' is missing or empty")
+        elif address.startswith("C...") or address == "C...":
+            errors.append(f"Contract '{cname}': 'address' is still a placeholder ('{address}')")
+        elif not address.startswith("C"):
+            errors.append(f"Contract '{cname}': 'address' does not look like a Soroban contract ID (expected C…, got '{address[:8]}…')")
+
+if errors:
+    print("ERROR: artifacts/addresses.json schema validation failed:", file=sys.stderr)
+    for e in errors:
+        print(f"  - {e}", file=sys.stderr)
+    sys.exit(1)
+
+print("Schema validation passed.")
+PY

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,12 +1,130 @@
 #!/usr/bin/env bash
+# verify.sh — post-deployment WASM hash verification.
+#
+# Confirms that the WASM hashes of deployed contracts on the network match
+# the locally built artifacts. Exits non-zero and prints a clear diff if any
+# mismatch is detected.
+#
+# Required environment variables:
+#   SOROBAN_RPC_URL        — Soroban RPC endpoint
+#   INVOICE_CONTRACT_ID    — deployed invoice contract ID  (C…)
+#   TREASURY_CONTRACT_ID   — deployed treasury contract ID (C…)
+#   COMPLIANCE_CONTRACT_ID — deployed compliance contract ID (C…)
+#
+# Optional:
+#   CONTRACTS_DIR          — path to built WASM artifacts
+#                            (default: ../COMEBACKHERE-contracts/target/wasm32-unknown-unknown/release)
 set -euo pipefail
 
-test -f abis/invoice.json
-test -f abis/treasury.json
-echo "ABI metadata present."
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-if [ -f abis/deployed.testnet.json ]; then
-  echo "Testnet deployment metadata present."
+# ── ABI metadata sanity check ─────────────────────────────────────────────────
+echo "Checking ABI metadata…"
+test -f "$ROOT_DIR/abis/invoice.json"    || { echo "ERROR: abis/invoice.json missing";    exit 1; }
+test -f "$ROOT_DIR/abis/treasury.json"   || { echo "ERROR: abis/treasury.json missing";   exit 1; }
+test -f "$ROOT_DIR/abis/compliance.json" || { echo "ERROR: abis/compliance.json missing"; exit 1; }
+echo "  ABI metadata present."
+
+# ── Deployment metadata check ─────────────────────────────────────────────────
+if [ -f "$ROOT_DIR/abis/deployed.testnet.json" ]; then
+  echo "  Testnet deployment metadata present."
 else
   echo "Warning: abis/deployed.testnet.json not found. Run scripts/deploy_testnet.sh first."
 fi
+
+# ── WASM hash verification ────────────────────────────────────────────────────
+# Only run when the required env vars are set (i.e. called post-deployment).
+if [[ -z "${SOROBAN_RPC_URL:-}" || -z "${INVOICE_CONTRACT_ID:-}" ]]; then
+  echo "Skipping WASM hash verification (SOROBAN_RPC_URL / CONTRACT_IDs not set)."
+  echo "Done."
+  exit 0
+fi
+
+: "${TREASURY_CONTRACT_ID:?TREASURY_CONTRACT_ID is required for WASM verification}"
+: "${COMPLIANCE_CONTRACT_ID:?COMPLIANCE_CONTRACT_ID is required for WASM verification}"
+
+CONTRACTS_DIR="${CONTRACTS_DIR:-$ROOT_DIR/../COMEBACKHERE-contracts/target/wasm32-unknown-unknown/release}"
+
+FAIL=0
+MISMATCHES=()
+
+verify_contract() {
+  local name="$1"
+  local contract_id="$2"
+  local wasm_file="$3"
+
+  if [[ ! -f "$wasm_file" ]]; then
+    echo "ERROR: local WASM artifact not found: $wasm_file" >&2
+    FAIL=1
+    MISMATCHES+=("$name: local artifact missing")
+    return
+  fi
+
+  # Compute SHA-256 of the local WASM (hex, no filename suffix)
+  local local_hash
+  local_hash=$(sha256sum "$wasm_file" | awk '{print $1}')
+
+  # Fetch the deployed contract WASM hash via Soroban RPC getContractWasmByContractId
+  local rpc_response
+  rpc_response=$(curl -sf -X POST "$SOROBAN_RPC_URL" \
+    -H "Content-Type: application/json" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getContractWasmByContractId\",\"params\":{\"contract_id\":\"$contract_id\"}}" \
+    2>/dev/null || true)
+
+  local deployed_hash=""
+  if [[ -n "$rpc_response" ]]; then
+    # The RPC returns the WASM as base64 under result.wasm; hash it for comparison.
+    deployed_hash=$(echo "$rpc_response" \
+      | python3 -c "
+import sys, json, hashlib, base64
+data = json.load(sys.stdin)
+wasm_b64 = (data.get('result') or {}).get('wasm', '')
+if not wasm_b64:
+    sys.exit(1)
+wasm_bytes = base64.b64decode(wasm_b64)
+print(hashlib.sha256(wasm_bytes).hexdigest())
+" 2>/dev/null || true)
+  fi
+
+  if [[ -z "$deployed_hash" ]]; then
+    echo "WARNING: Could not retrieve deployed WASM hash for $name ($contract_id)." >&2
+    echo "         Skipping hash comparison for this contract." >&2
+    return
+  fi
+
+  if [[ "$local_hash" == "$deployed_hash" ]]; then
+    echo "  ✓ $name: hash match ($local_hash)"
+  else
+    echo "  ✗ $name: HASH MISMATCH" >&2
+    echo "    local:    $local_hash" >&2
+    echo "    deployed: $deployed_hash" >&2
+    FAIL=1
+    MISMATCHES+=("$name")
+  fi
+}
+
+echo ""
+echo "Verifying deployed WASM hashes against local build artifacts…"
+
+verify_contract "invoice" \
+  "$INVOICE_CONTRACT_ID" \
+  "$CONTRACTS_DIR/comebackhere_invoice.wasm"
+
+verify_contract "treasury" \
+  "$TREASURY_CONTRACT_ID" \
+  "$CONTRACTS_DIR/comebackhere_treasury.wasm"
+
+verify_contract "compliance" \
+  "$COMPLIANCE_CONTRACT_ID" \
+  "$CONTRACTS_DIR/comebackhere_compliance.wasm"
+
+if (( FAIL )); then
+  echo ""
+  echo "VERIFICATION FAILED — the following contracts have WASM hash mismatches:" >&2
+  printf '  - %s\n' "${MISMATCHES[@]}" >&2
+  echo "Ensure you are comparing the correct build artifacts to the correct deployment." >&2
+  exit 1
+fi
+
+echo ""
+echo "All WASM hashes verified successfully."


### PR DESCRIPTION
- feat: add backend REST endpoint POST /invoices/:id/cancel (#112)
  - Enforces merchant-only access by comparing caller to invoice.merchant
  - Maps contract Unauthorized(1) → HTTP 403 with structured error body
  - Returns updated status (Cancelled) and transaction hash on success
  - Follows existing pay_invoice pattern (SorobanClient method + Axum handler)

- feat: add backend REST endpoint POST /invoices/:id/refund (#114)
  - Enforces payer-only access by comparing caller to invoice.payer
  - Maps contract RefundNotRequested(10) error → HTTP 422 with descriptive body
  - Returns updated status (RefundRequested) and transaction hash on success
  - Follows existing pay_invoice pattern

- chore: add scripts/verify.sh to CI post-deployment (#113)
  - Expands verify.sh with WASM hash comparison against locally built artifacts
  - Fetches deployed contract WASM via Soroban RPC getContractWasmByContractId
  - Fails CI with a clear per-contract diff if any hash mismatch is detected
  - Adds ci-post-deploy-verify.yml workflow: deploy → verify → export-addresses
  - ABI metadata presence check retained from original implementation

- chore: add export_deployed_addresses.sh schema validation (#115)
  - Adds Python schema validation step after writing artifacts/addresses.json
  - Validates required top-level fields, contract name coverage, and non-placeholder addresses
  - Fails deployment workflow if validation fails or required fields are missing
  - export-addresses job runs as a required step in ci-post-deploy-verify.yml

Closes #112
Closes #113
Closes #114
Closes #115

## Summary

- Describe the purpose of this PR in one or two sentences.

## Checklist

- [ ] Closes #__
- [ ] Tests added or updated
- [ ] ABI snapshot updated if contract sources changed (`abis/` and `COMEBACKHERE-contracts/`)
- [ ] Screenshots attached if UI changed
- [ ] Documentation updated if needed

## Notes

- For contract changes, verify ABI snapshot hygiene with `make check-abi-snapshots`.
- For UI changes, include screenshots or screen recordings to help reviewers.
