### PR TITLE
fix: fix silent failure in abi snapshot hygiene check

### DIFF
--- a/scripts/check_abi_snapshot_hygiene.sh
+++ b/scripts/check_abi_snapshot_hygiene.sh
@@ -2,6 +2,36 @@
 # Ensure committed ABI metadata stays paired with contract source edits.
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# 1. Existence check — fail loudly if any required ABI file is missing.
+# ---------------------------------------------------------------------------
+REQUIRED_ABIS=(
+  abis/invoice.json
+  abis/treasury.json
+  abis/compliance.json
+)
+
+missing=0
+for abi_file in "${REQUIRED_ABIS[@]}"; do
+  if [ ! -f "$REPO_ROOT/$abi_file" ]; then
+    echo "ERROR: required ABI snapshot is missing: $abi_file" >&2
+    missing=1
+  fi
+done
+
+if [ "$missing" -ne 0 ]; then
+  echo "" >&2
+  echo "One or more required ABI snapshots are missing from abis/." >&2
+  echo "Restore the files or regenerate them with:" >&2
+  echo "  scripts/generate_abi_metadata.sh abis" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Staged-pairing check — ABI and contract source changes must go together.
+# ---------------------------------------------------------------------------
 abi_changed="$(git diff --cached --name-only -- 'abis/*.json' || true)"
 contract_src_changed="$(git diff --cached --name-only -- '../COMEBACKHERE-contracts/contracts/*/src/' || true)"
 


### PR DESCRIPTION
Closes #262 
Closes #263 
Closes #266 
Closes #267 
## Summary

`scripts/check_abi_snapshot_hygiene.sh` previously relied solely on `git diff --cached` to detect ABI problems. That only inspects staged changes — if an expected ABI file was deleted from `abis/` without being staged, both diff branches would silently produce empty output and the script would exit 0.

This PR adds an explicit existence check for all three required ABI snapshot files before any diff logic runs.

## Changes

- Enumerate the three required ABI files (`abis/invoice.json`, `abis/treasury.json`, `abis/compliance.json`) in a `REQUIRED_ABIS` array.
- Loop over the array and emit a named `ERROR:` line to stderr for each missing file, accumulating failures so all missing files are reported in a single run.
- Exit 1 with a remediation hint (`scripts/generate_abi_metadata.sh abis`) if any file is absent.
- The existing staged-pairing logic (ABI ↔ contract-source) is unchanged.

## Testing

| Scenario | Exit code |
|---|---|
| `abis/invoice.json` deleted | 1 ✅ |
| `abis/treasury.json` deleted | 1 ✅ |
| `abis/compliance.json` deleted | 1 ✅ |
| All three deleted | 1 ✅ (all three named in output) |
| All files present, nothing staged | 0 ✅ |