### PR TITLE
feat: reorg handling, env validation, correlation IDs, release-escrow auth tests (#221-224)

### DIFF
--- a/comebackhere-backend/src/app.ts
+++ b/comebackhere-backend/src/app.ts
@@ -8,10 +8,14 @@ import thresholdRouter from "./routes/threshold.js"
 import disputesRouter from "./routes/disputes.js"
 import analyticsRouter from "./routes/analytics.js"
 import { rateLimitMiddleware } from "./middleware/rateLimiter.js"
+import { correlationIdMiddleware } from "./middleware/correlationId.js"
 
 export function createApp() {
   const app = express()
   app.use(express.json())
+  // Attach / propagate X-Request-Id before any other middleware so every log
+  // line and downstream call can reference the same correlation ID.
+  app.use(correlationIdMiddleware)
   app.use(rateLimitMiddleware)
   app.use("/invoices", invoicesRouter)
   app.use("/invoices", releaseEscrowRouter)

--- a/comebackhere-backend/src/db/mongo.ts
+++ b/comebackhere-backend/src/db/mongo.ts
@@ -19,6 +19,8 @@ export interface IndexerCursor {
   paging_token: string | null
   last_ledger: number
   updated_at: Date
+  /** Event IDs already applied — used for reorg / replay deduplication. */
+  processed_event_ids?: string[]
 }
 
 let client: MongoClient | null = null

--- a/comebackhere-backend/src/index.ts
+++ b/comebackhere-backend/src/index.ts
@@ -1,11 +1,57 @@
 import { createApp } from "./app.js"
 import { startTreasuryIndexer } from "./services/treasury-indexer.js"
 
-const PORT = process.env.PORT ?? "3000"
-const app = createApp()
+// ---------------------------------------------------------------------------
+// Startup environment variable validation (issue #222)
+//
+// Fail fast with a single clear message listing every missing variable rather
+// than crashing on first use deep inside the application.
+// ---------------------------------------------------------------------------
 
-startTreasuryIndexer()
+/** All env vars that must be present for the server to function correctly. */
+export const REQUIRED_ENV_VARS = [
+  "MONGODB_URI",
+  "REDIS_URL",
+  "SOROBAN_RPC_URL",
+  "TREASURY_CONTRACT_ID",
+  "INVOICE_CONTRACT_ID",
+  "ADMIN_KEY",
+  "WEBHOOK_SECRET",
+] as const
 
-app.listen(Number(PORT), () => {
-  console.log(`comebackhere-backend listening on port ${PORT}`)
-})
+/**
+ * Validates that all required environment variables are set.
+ * Accepts an optional env map so that tests can pass a controlled object
+ * rather than relying on `process.env`.
+ *
+ * Throws an Error that lists *every* missing variable in one message.
+ */
+export function validateEnv(env: Record<string, string | undefined> = process.env): void {
+  const missing = REQUIRED_ENV_VARS.filter((key) => !env[key])
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variable${missing.length > 1 ? "s" : ""}:\n` +
+        missing.map((k) => `  - ${k}`).join("\n") +
+        "\nSet the above variables before starting the server.",
+    )
+  }
+}
+
+// Only execute the server bootstrap when this file is run as the main entry
+// point, not when it is imported by tests or other modules.
+const isMain =
+  process.argv[1] != null &&
+  new URL(import.meta.url).pathname === new URL(process.argv[1], import.meta.url).pathname
+
+if (isMain) {
+  validateEnv()
+
+  const PORT = process.env.PORT ?? "3000"
+  const app = createApp()
+
+  startTreasuryIndexer()
+
+  app.listen(Number(PORT), () => {
+    console.log(`comebackhere-backend listening on port ${PORT}`)
+  })
+}

--- a/comebackhere-backend/src/middleware/correlationId.ts
+++ b/comebackhere-backend/src/middleware/correlationId.ts
@@ -1,0 +1,42 @@
+/**
+ * Correlation ID middleware (issue #224)
+ *
+ * Attaches a unique `X-Request-Id` header to every request and response so
+ * that a single request can be traced across logs, the treasury indexer, and
+ * webhook delivery.
+ *
+ * Behaviour:
+ *  - If the incoming request already carries an `X-Request-Id` header, that
+ *    value is preserved and echoed back on the response (client-supplied ID).
+ *  - Otherwise a new UUID v4 is generated and set on both the request and the
+ *    response.
+ *
+ * The ID is stored on `res.locals.requestId` so route handlers and other
+ * middleware can include it in log lines:
+ *
+ *   console.log(`[requestId=${res.locals.requestId}] processing invoice`)
+ */
+
+import { type Request, type Response, type NextFunction } from "express"
+import { randomUUID } from "node:crypto"
+
+export function correlationIdMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const incomingId = req.headers["x-request-id"]
+  // Only accept a single string value; ignore arrays (malformed headers)
+  const requestId =
+    typeof incomingId === "string" && incomingId.trim() !== ""
+      ? incomingId.trim()
+      : randomUUID()
+
+  // Make the ID available to downstream handlers and logging
+  res.locals.requestId = requestId
+
+  // Echo the ID on the response so callers can correlate client-side
+  res.setHeader("X-Request-Id", requestId)
+
+  next()
+}

--- a/comebackhere-backend/src/services/treasury-indexer.ts
+++ b/comebackhere-backend/src/services/treasury-indexer.ts
@@ -46,19 +46,37 @@ async function saveCursor(
   database: Awaited<ReturnType<typeof connectMongo>>,
   pagingToken: string | null,
   lastLedger: number,
+  newEventIds: string[] = [],
 ) {
   const cursors = getCursorsCollection(database)
-  await cursors.updateOne(
-    { _id: CURSOR_ID },
-    {
-      $set: {
-        paging_token: pagingToken,
-        last_ledger: lastLedger,
-        updated_at: new Date(),
+  const update: Record<string, unknown> = {
+    paging_token: pagingToken,
+    last_ledger: lastLedger,
+    updated_at: new Date(),
+  }
+
+  if (newEventIds.length > 0) {
+    await cursors.updateOne(
+      { _id: CURSOR_ID },
+      {
+        $set: update,
+        // Keep only the most recent 1 000 event IDs to bound document size
+        $push: {
+          processed_event_ids: {
+            $each: newEventIds,
+            $slice: -1000,
+          },
+        } as any,
       },
-    },
-    { upsert: true },
-  )
+      { upsert: true },
+    )
+  } else {
+    await cursors.updateOne(
+      { _id: CURSOR_ID },
+      { $set: update },
+      { upsert: true },
+    )
+  }
 }
 
 async function processSettlementProposed(
@@ -143,6 +161,24 @@ async function processSettlementExecuted(
   )
 }
 
+/**
+ * Build a deterministic, unique identifier for an on-chain event so that
+ * replaying an overlapping window (e.g. after a reorg or indexer restart)
+ * never applies the same side-effect twice.
+ *
+ * Format: "<pagingToken>" when available (Soroban paging tokens already encode
+ * ledger + tx index + event index), falling back to "<txHash>:<eventType>:<settlementId>".
+ */
+export function buildEventId(
+  pagingToken: string | undefined,
+  txHash: string,
+  eventType: string,
+  settlementId: number,
+): string {
+  if (pagingToken) return pagingToken
+  return `${txHash}:${eventType}:${settlementId}`
+}
+
 export async function processIndexerBatch(
   client: SorobanClient,
   treasuryContractId: string,
@@ -164,35 +200,57 @@ export async function processIndexerBatch(
     ...(cursor.paging_token ? { cursor: cursor.paging_token } : {}),
   })
 
+  // Collect the set of already-processed event IDs stored in the cursor document
+  // so we can skip duplicates that appear when replaying an overlapping window
+  // after a reorg or an indexer restart that resumed from an earlier ledger.
+  const processedIds: Set<string> = new Set(cursor.processed_event_ids ?? [])
+
   let processed = 0
   let lastPagingToken = cursor.paging_token
+  const newEventIds: string[] = []
+
   for (const event of response.events ?? []) {
     const eventType = topicSymbol(event.topic, 0)
     const txHash = event.txHash ?? ""
     lastPagingToken = event.pagingToken ?? lastPagingToken
 
+    if (
+      eventType !== "settlement_proposed" &&
+      eventType !== "settlement_approved" &&
+      eventType !== "settlement_executed"
+    ) {
+      continue
+    }
+
+    const settlementId = Number(valueU64(event.value, 0))
+    const eventId = buildEventId(event.pagingToken, txHash, eventType, settlementId)
+
+    // De-duplicate: skip events we have already applied (reorg / replay protection)
+    if (processedIds.has(eventId)) {
+      console.log(`[treasury-indexer] skipping duplicate event id=${eventId}`)
+      continue
+    }
+
     if (eventType === "settlement_proposed") {
-      const settlementId = Number(valueU64(event.value, 0))
       const token = valueAddress(event.value, 1)
       const amount = valueU64(event.value, 2)
       const merchant = valueAddress(event.value, 3)
       await processSettlementProposed(settlements, settlementId, token, amount, merchant, txHash)
-      processed++
     } else if (eventType === "settlement_approved") {
-      const settlementId = Number(valueU64(event.value, 0))
       const signer = valueAddress(event.value, 1)
       const newWeight = valueU64(event.value, 3)
       await processSettlementApproved(settlements, settlementId, signer, newWeight)
-      processed++
     } else if (eventType === "settlement_executed") {
-      const settlementId = Number(valueU64(event.value, 0))
       await processSettlementExecuted(settlements, settlementId, txHash)
-      processed++
     }
+
+    processedIds.add(eventId)
+    newEventIds.push(eventId)
+    processed++
   }
 
   const lastLedger = response.latestLedger ?? cursor.last_ledger
-  await saveCursor(database, lastPagingToken, lastLedger)
+  await saveCursor(database, lastPagingToken, lastLedger, newEventIds)
 
   if (processed > 0) {
     console.log(

--- a/comebackhere-backend/src/tests/correlationId.test.ts
+++ b/comebackhere-backend/src/tests/correlationId.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest"
+import request from "supertest"
+import { createApp } from "../app.js"
+
+// Attach a simple probe route so we can test the middleware in isolation
+// without hitting any real route logic.
+function createTestApp() {
+  const app = createApp()
+  app.get("/probe", (_req, res) => {
+    res.status(200).json({ requestId: res.locals.requestId })
+  })
+  return app
+}
+
+describe("correlationIdMiddleware", () => {
+  it("adds an X-Request-Id header to the response", async () => {
+    const app = createTestApp()
+    const res = await request(app).get("/probe")
+    expect(res.headers["x-request-id"]).toBeDefined()
+    expect(typeof res.headers["x-request-id"]).toBe("string")
+    expect(res.headers["x-request-id"].length).toBeGreaterThan(0)
+  })
+
+  it("generates a new UUID when the client does not supply X-Request-Id", async () => {
+    const app = createTestApp()
+    const res = await request(app).get("/probe")
+    // UUID v4 pattern
+    expect(res.headers["x-request-id"]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    )
+  })
+
+  it("preserves a client-supplied X-Request-Id rather than overwriting it", async () => {
+    const clientId = "my-trace-id-12345"
+    const app = createTestApp()
+    const res = await request(app).get("/probe").set("X-Request-Id", clientId)
+
+    expect(res.headers["x-request-id"]).toBe(clientId)
+  })
+
+  it("stores the request ID in res.locals.requestId for downstream handlers", async () => {
+    const clientId = "locals-check-id"
+    const app = createTestApp()
+    const res = await request(app).get("/probe").set("X-Request-Id", clientId)
+
+    expect(res.body.requestId).toBe(clientId)
+  })
+
+  it("generates a different ID for each request when no client ID is supplied", async () => {
+    const app = createTestApp()
+    const [res1, res2] = await Promise.all([
+      request(app).get("/probe"),
+      request(app).get("/probe"),
+    ])
+
+    expect(res1.headers["x-request-id"]).not.toBe(res2.headers["x-request-id"])
+  })
+})

--- a/comebackhere-backend/src/tests/env-validation.test.ts
+++ b/comebackhere-backend/src/tests/env-validation.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest"
+import { validateEnv } from "../index.js"
+
+const FULL_ENV: Record<string, string> = {
+  MONGODB_URI: "mongodb://localhost:27017",
+  REDIS_URL: "redis://localhost:6379",
+  SOROBAN_RPC_URL: "http://localhost:8000",
+  TREASURY_CONTRACT_ID: "CTREASURY",
+  INVOICE_CONTRACT_ID: "CINVOICE",
+  ADMIN_KEY: "secret-admin",
+  WEBHOOK_SECRET: "secret-webhook",
+}
+
+describe("validateEnv", () => {
+  it("does not throw when all required vars are present", () => {
+    expect(() => validateEnv(FULL_ENV)).not.toThrow()
+  })
+
+  it("throws when a single required var is missing", () => {
+    const env = { ...FULL_ENV }
+    delete env.MONGODB_URI
+
+    expect(() => validateEnv(env)).toThrow(/MONGODB_URI/)
+  })
+
+  it("lists every missing var in one error, not just the first one found", () => {
+    const env = { ...FULL_ENV }
+    delete env.REDIS_URL
+    delete env.WEBHOOK_SECRET
+
+    let err: Error | null = null
+    try {
+      validateEnv(env)
+    } catch (e) {
+      err = e as Error
+    }
+
+    expect(err).not.toBeNull()
+    expect(err!.message).toMatch(/REDIS_URL/)
+    expect(err!.message).toMatch(/WEBHOOK_SECRET/)
+  })
+
+  it("includes all seven required vars in the error when none are set", () => {
+    let err: Error | null = null
+    try {
+      validateEnv({})
+    } catch (e) {
+      err = e as Error
+    }
+
+    expect(err).not.toBeNull()
+    const message = err!.message
+    expect(message).toMatch(/MONGODB_URI/)
+    expect(message).toMatch(/REDIS_URL/)
+    expect(message).toMatch(/SOROBAN_RPC_URL/)
+    expect(message).toMatch(/TREASURY_CONTRACT_ID/)
+    expect(message).toMatch(/INVOICE_CONTRACT_ID/)
+    expect(message).toMatch(/ADMIN_KEY/)
+    expect(message).toMatch(/WEBHOOK_SECRET/)
+  })
+
+  it("throws with a human-readable hint to set the missing variables", () => {
+    expect(() => validateEnv({})).toThrow(/Set the above variables/)
+  })
+})

--- a/comebackhere-backend/src/tests/release-escrow.test.ts
+++ b/comebackhere-backend/src/tests/release-escrow.test.ts
@@ -5,6 +5,15 @@ import { releaseEscrow } from "../routes/release-escrow.js"
 import type { SorobanClient } from "../lib/soroban.js"
 import { SorobanRpc, SorobanDataBuilder, xdr } from "stellar-sdk"
 
+// ── Mock lib/soroban so no live Soroban node is required ─────────────────────
+vi.mock("../lib/soroban.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../lib/soroban.js")>()
+  return {
+    ...original,
+    buildSorobanClient: vi.fn(),
+  }
+})
+
 // Pre-parsed simulation success accepted by assembleTransaction without XDR parsing
 const PARSED_SIM_SUCCESS = {
   _parsed: true,
@@ -108,6 +117,104 @@ describe("POST /invoices/:id/release-escrow — HTTP layer", () => {
       .send()
     expect(res.status).toBe(503)
     expect(res.body.error).toMatch(/misconfiguration/)
+  })
+})
+
+// ── Authorization tests (issue #223) ─────────────────────────────────────────
+describe("POST /invoices/:id/release-escrow — authorization", () => {
+  let envBackup: Record<string, string | undefined>
+
+  beforeEach(async () => {
+    envBackup = {}
+    for (const key of Object.keys(ENV)) {
+      envBackup[key] = process.env[key]
+      process.env[key] = ENV[key as keyof typeof ENV]
+    }
+
+    // Wire buildSorobanClient to return a mock for end-to-end HTTP tests
+    const sorobanMod = await import("../lib/soroban.js")
+    vi.mocked(sorobanMod.buildSorobanClient).mockReturnValue(
+      makeMockClient({
+        getAccount: vi.fn().mockResolvedValue(fakeAccount),
+        simulateTransaction: vi.fn().mockResolvedValue(PARSED_SIM_SUCCESS),
+        sendTransaction: vi.fn().mockResolvedValue({ status: "PENDING", hash: "release-ok-hash" }),
+        getTransaction: vi.fn().mockResolvedValue({
+          status: SorobanRpc.Api.GetTransactionStatus.SUCCESS,
+          latestLedger: 1,
+          latestLedgerCloseTime: 0,
+          oldestLedger: 1,
+          oldestLedgerCloseTime: 0,
+        }),
+      }),
+    )
+  })
+
+  afterEach(() => {
+    for (const [key, val] of Object.entries(envBackup)) {
+      if (val === undefined) delete process.env[key]
+      else process.env[key] = val
+    }
+    vi.restoreAllMocks()
+  })
+
+  it("200 — authorized merchant with correct x-admin-key succeeds (authorized-merchant-success)", async () => {
+    const app = createApp()
+    const res = await request(app)
+      .post("/invoices/42/release-escrow")
+      .set("x-admin-key", ADMIN_KEY)
+      .send()
+
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({
+      invoice_id: 42,
+      status: "Released",
+      tx_hash: expect.any(String),
+    })
+  })
+
+  it("401 — unauthorized caller without x-admin-key is rejected (unauthorized-caller-rejection)", async () => {
+    const app = createApp()
+    const res = await request(app)
+      .post("/invoices/42/release-escrow")
+      .send()
+
+    expect(res.status).toBe(401)
+    expect(res.body.error).toMatch(/Unauthorized/)
+  })
+
+  it("401 — unauthorized caller with wrong x-admin-key is rejected (unauthorized-caller-rejection)", async () => {
+    const app = createApp()
+    const res = await request(app)
+      .post("/invoices/42/release-escrow")
+      .set("x-admin-key", "not-the-real-key")
+      .send()
+
+    expect(res.status).toBe(401)
+    expect(res.body.error).toMatch(/Unauthorized/)
+  })
+
+  it("403 — on-chain Unauthorized contract error maps to 403 Forbidden", async () => {
+    // Override the mock to return an on-chain auth error
+    const sorobanMod = await import("../lib/soroban.js")
+    vi.mocked(sorobanMod.buildSorobanClient).mockReturnValue(
+      makeMockClient({
+        getAccount: vi.fn().mockResolvedValue(fakeAccount),
+        simulateTransaction: vi.fn().mockResolvedValue({
+          error: "HostError: Error(Contract, #1) UNAUTHORIZED",
+          latestLedger: 1,
+        }),
+      }),
+    )
+
+    const app = createApp()
+    const res = await request(app)
+      .post("/invoices/42/release-escrow")
+      .set("x-admin-key", ADMIN_KEY)
+      .send()
+
+    expect(res.status).toBe(403)
+    expect(res.body.error).toMatch(/authoris/)
+    expect(res.body.code).toBe(1)
   })
 })
 

--- a/comebackhere-backend/src/tests/treasury-indexer.test.ts
+++ b/comebackhere-backend/src/tests/treasury-indexer.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { processIndexerBatch, buildEventId } from "../services/treasury-indexer.js"
+import type { SorobanClient } from "../lib/soroban.js"
+import type { Db, Collection } from "mongodb"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEvent(overrides: Partial<{
+  pagingToken: string
+  txHash: string
+  eventType: string
+  settlementId: number
+  ledger: number
+}> = {}) {
+  const {
+    pagingToken = "tok-1",
+    txHash = "abc123",
+    eventType = "settlement_proposed",
+    settlementId = 1,
+    ledger = 100,
+  } = overrides
+
+  // Encode topic / value in a format that topicSymbol / valueU64 / valueAddress
+  // can read.  We use the same helper patterns as the indexer itself.
+  const topicSym = (s: string) => ({ sym: () => ({ toString: () => s }) })
+  const u64Val = (n: number) => ({
+    u64: () => ({ toString: () => String(n) }),
+    address: () => null,
+    vec: () => null,
+  })
+  const vecVal = (...items: any[]) => ({ vec: () => items })
+
+  return {
+    pagingToken,
+    txHash,
+    ledger,
+    topic: [topicSym(eventType), u64Val(settlementId)],
+    value: vecVal(u64Val(settlementId), { address: () => ({ toString: () => "addr-token" }) }, u64Val(1000), { address: () => ({ toString: () => "addr-merchant" }) }),
+  }
+}
+
+function makeMockCursor(overrides: Partial<{
+  paging_token: string | null
+  last_ledger: number
+  processed_event_ids: string[]
+}> = {}) {
+  return {
+    _id: "treasury_settlement_events",
+    paging_token: overrides.paging_token ?? null,
+    last_ledger: overrides.last_ledger ?? 0,
+    processed_event_ids: overrides.processed_event_ids ?? [],
+    updated_at: new Date(),
+  }
+}
+
+function makeDatabase(cursorDoc: ReturnType<typeof makeMockCursor>) {
+  const updatedCursor = { ...cursorDoc }
+
+  const cursorsCollection = {
+    findOne: vi.fn().mockResolvedValue(updatedCursor),
+    updateOne: vi.fn().mockImplementation(async (_filter: any, update: any) => {
+      if (update.$push?.processed_event_ids) {
+        const each: string[] = update.$push.processed_event_ids.$each ?? []
+        updatedCursor.processed_event_ids = [
+          ...(updatedCursor.processed_event_ids ?? []),
+          ...each,
+        ].slice(-1000)
+      }
+      if (update.$set) {
+        Object.assign(updatedCursor, update.$set)
+      }
+    }),
+  }
+
+  const settlementsCollection = {
+    updateOne: vi.fn().mockResolvedValue({}),
+  }
+
+  return {
+    collection: vi.fn().mockImplementation((name: string) => {
+      if (name === "indexer_cursors") return cursorsCollection
+      return settlementsCollection
+    }),
+    _cursors: cursorsCollection,
+    _settlements: settlementsCollection,
+  } as unknown as Db & { _cursors: typeof cursorsCollection; _settlements: typeof settlementsCollection }
+}
+
+function makeMockClient(events: ReturnType<typeof makeEvent>[], latestLedger = 200): SorobanClient {
+  return {
+    getEvents: vi.fn().mockResolvedValue({ events, latestLedger }),
+    getLatestLedger: vi.fn().mockResolvedValue({ sequence: latestLedger }),
+    getAccount: vi.fn(),
+    simulateTransaction: vi.fn(),
+    sendTransaction: vi.fn(),
+    getTransaction: vi.fn(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// buildEventId unit tests
+// ---------------------------------------------------------------------------
+describe("buildEventId", () => {
+  it("returns the paging token when available", () => {
+    expect(buildEventId("pg-tok", "txhash", "settlement_proposed", 1)).toBe("pg-tok")
+  })
+
+  it("falls back to tx:type:id when paging token is absent", () => {
+    expect(buildEventId(undefined, "txhash", "settlement_proposed", 1)).toBe(
+      "txhash:settlement_proposed:1",
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// processIndexerBatch — deduplication / reorg tests
+// ---------------------------------------------------------------------------
+describe("processIndexerBatch — reorg deduplication", () => {
+  const CONTRACT_ID = "CONTRACT_TEST"
+
+  it("processes a new event and returns count 1", async () => {
+    const event = makeEvent({ pagingToken: "tok-1", txHash: "tx1", eventType: "settlement_proposed", settlementId: 1 })
+    const db = makeDatabase(makeMockCursor())
+    const client = makeMockClient([event])
+
+    const count = await processIndexerBatch(client, CONTRACT_ID, db)
+    expect(count).toBe(1)
+    expect((db as any)._settlements.updateOne).toHaveBeenCalledTimes(1)
+  })
+
+  it("skips a duplicate event in a replayed window and returns count 0", async () => {
+    // Cursor already has "tok-1" in its processed_event_ids → duplicate
+    const event = makeEvent({ pagingToken: "tok-1", txHash: "tx1", eventType: "settlement_proposed", settlementId: 1 })
+    const db = makeDatabase(makeMockCursor({ processed_event_ids: ["tok-1"] }))
+    const client = makeMockClient([event])
+
+    const count = await processIndexerBatch(client, CONTRACT_ID, db)
+    expect(count).toBe(0)
+    // The settlements collection must NOT have been written to
+    expect((db as any)._settlements.updateOne).not.toHaveBeenCalled()
+  })
+
+  it("processes only the new event when an overlapping batch contains one duplicate and one new event", async () => {
+    const dup = makeEvent({ pagingToken: "tok-1", txHash: "tx1", eventType: "settlement_proposed", settlementId: 1 })
+    const fresh = makeEvent({ pagingToken: "tok-2", txHash: "tx2", eventType: "settlement_proposed", settlementId: 2 })
+    const db = makeDatabase(makeMockCursor({ processed_event_ids: ["tok-1"] }))
+    const client = makeMockClient([dup, fresh])
+
+    const count = await processIndexerBatch(client, CONTRACT_ID, db)
+    expect(count).toBe(1)
+    // Only the fresh event should have triggered a DB write
+    expect((db as any)._settlements.updateOne).toHaveBeenCalledTimes(1)
+  })
+
+  it("handles settlement_approved deduplication", async () => {
+    const event = makeEvent({ pagingToken: "tok-3", txHash: "tx3", eventType: "settlement_approved", settlementId: 5 })
+    const db = makeDatabase(makeMockCursor({ processed_event_ids: ["tok-3"] }))
+    const client = makeMockClient([event])
+
+    const count = await processIndexerBatch(client, CONTRACT_ID, db)
+    expect(count).toBe(0)
+    expect((db as any)._settlements.updateOne).not.toHaveBeenCalled()
+  })
+
+  it("handles settlement_executed deduplication", async () => {
+    const event = makeEvent({ pagingToken: "tok-4", txHash: "tx4", eventType: "settlement_executed", settlementId: 7 })
+    const db = makeDatabase(makeMockCursor({ processed_event_ids: ["tok-4"] }))
+    const client = makeMockClient([event])
+
+    const count = await processIndexerBatch(client, CONTRACT_ID, db)
+    expect(count).toBe(0)
+    expect((db as any)._settlements.updateOne).not.toHaveBeenCalled()
+  })
+
+  it("records processed event IDs so a subsequent replay also deduplicates", async () => {
+    const event = makeEvent({ pagingToken: "tok-5", txHash: "tx5", eventType: "settlement_proposed", settlementId: 9 })
+
+    // Build a real-ish cursor whose updateOne actually mutates the stored IDs
+    const cursorDoc = makeMockCursor()
+    const db = makeDatabase(cursorDoc)
+    const client = makeMockClient([event])
+
+    // First pass — processes the event
+    const count1 = await processIndexerBatch(client, CONTRACT_ID, db)
+    expect(count1).toBe(1)
+
+    // Simulate a second call where the cursor's findOne returns the already-updated cursor doc
+    // (the makeDatabase mock's findOne always returns the same updatedCursor ref which was
+    //  mutated by the updateOne mock above)
+    const count2 = await processIndexerBatch(client, CONTRACT_ID, db)
+    expect(count2).toBe(0)
+  })
+})

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -166,3 +166,41 @@ Or remap the Docker Redis port as shown above.
 - **Check service health**: `docker compose ps` shows healthcheck status for each service
 - **Verify RPC is responding**: `curl http://localhost:8000/health`
 - **Verify Redis is responding**: `docker compose exec redis redis-cli ping` (should return `PONG`)
+
+## Request Tracing with Correlation IDs
+
+Every request handled by `comebackhere-backend` carries a unique `X-Request-Id`
+header that is echoed back on the response. This ID is the primary key for
+tracing a single request across backend logs, the treasury indexer, and webhook
+delivery.
+
+### How it works
+
+- If your client already sets an `X-Request-Id` header the backend preserves
+  that value unchanged.
+- Otherwise the backend generates a new UUID v4 and attaches it to both the
+  request context (`res.locals.requestId`) and the response header.
+
+### Filtering logs by correlation ID
+
+Capture the ID from a response and grep backend logs:
+
+```sh
+# Store the ID from a curl call
+REQUEST_ID=$(curl -si http://localhost:3000/invoices/1 | grep -i x-request-id | awk '{print $2}' | tr -d '\r')
+echo "Tracing request: $REQUEST_ID"
+
+# Filter Docker logs
+docker compose logs backend 2>&1 | grep "$REQUEST_ID"
+```
+
+### Supplying your own trace ID
+
+Pass an existing trace ID from your client or a distributed tracing system:
+
+```sh
+curl -H "X-Request-Id: my-trace-id-abc123" http://localhost:3000/invoices/1
+```
+
+The response will echo the same `X-Request-Id: my-trace-id-abc123` header,
+confirming the backend used your ID throughout the request lifecycle.


### PR DESCRIPTION
## Summary

Implements issues #221, #222, #223, and #224 in `comebackhere-backend`.

---

### #221 — Reorg handling in treasury-indexer.ts

**Problem:** The treasury indexer had no deduplication; replaying an overlapping event window after a chain reorg or indexer restart would double-process events.

**Changes:**
- Add `buildEventId()`: deterministic event key from paging token (fallback: `txHash:eventType:settlementId`).
- Track `processed_event_ids` in the cursor document (capped at 1 000 entries).
- Skip events whose ID is already in the set before applying side effects.
- Update `IndexerCursor` type in `db/mongo.ts`.

**Tests:** 8 tests in `treasury-indexer.test.ts` covering new events, single duplicates, mixed batches, all three event types.

---

### #222 — Startup env var validation

**Problem:** `index.ts` started without checking required env vars; crashes happened on first use with unhelpful errors.

**Changes:**
- Export `validateEnv(env?)` checks 7 required vars and throws a single error listing every missing one.
- Guard with `isMain` so test imports do not trigger the check.

**Tests:** 5 tests in `env-validation.test.ts`.

---

### #223 — Authorization tests for POST /invoices/:id/release-escrow

**Changes:**
- Add `vi.mock('../lib/soroban.js')` so tests run without a live Soroban node.
- 4 new authorization tests: 200 authorized success, 401 missing key, 401 wrong key, 403 on-chain contract auth error.

---

### #224 — Correlation ID middleware

**Changes:**
- New `middleware/correlationId.ts`: generates UUID v4 or preserves client `X-Request-Id`; stored in `res.locals.requestId`.
- Register `correlationIdMiddleware` as first middleware in `app.ts`.
- Add `X-Request-Id` tracing section to `docs/troubleshooting.md`.

**Tests:** 5 tests in `correlationId.test.ts`.

---

## Test output

```
Test Files  7 passed (7)
     Tests  54 passed (54)
  Duration  ~29s
```

Closes #221
Closes #222
Closes #223
Closes #224