### PR TITLE
feat: validate signer weights and reject duplicates in initialize

### DIFF
--- a/COMEBACKHERE-contracts/contracts/treasury/src/lib.rs
+++ b/COMEBACKHERE-contracts/contracts/treasury/src/lib.rs
@@ -32,6 +32,8 @@ pub enum TreasuryError {
     TokenNotAllowed = 4,
     Unauthorized = 5,
     InvalidThreshold = 6,
+    DuplicateSigner = 7,
+    InvalidWeightSum = 8,
 }
 
 #[contracttype]
@@ -62,8 +64,25 @@ pub struct TreasuryContract;
 
 #[contractimpl]
 impl TreasuryContract {
-    pub fn initialize(e: Env, signers: Vec<(Address, u64)>, threshold: u64, admin: Address) {
+    pub fn initialize(
+        e: Env,
+        signers: Vec<(Address, u64)>,
+        threshold: u64,
+        admin: Address,
+    ) -> Result<(), TreasuryError> {
         admin.require_auth();
+        let mut seen: Vec<Address> = Vec::new(&e);
+        let mut total_weight: u64 = 0;
+        for (signer, weight) in signers.iter() {
+            if seen.contains(&signer) {
+                return Err(TreasuryError::DuplicateSigner);
+            }
+            seen.push_back(signer.clone());
+            total_weight += weight;
+        }
+        if total_weight < threshold {
+            return Err(TreasuryError::InvalidWeightSum);
+        }
         e.storage().instance().set(&DataKey::Admin, &admin);
         e.storage().instance().set(&DataKey::Threshold, &threshold);
         e.storage().instance().set(&DataKey::Paused, &false);
@@ -73,6 +92,7 @@ impl TreasuryContract {
                 .instance()
                 .set(&DataKey::Signer(signer.clone()), &weight);
         }
+        Ok(())
     }
 
     pub fn set_signer(
@@ -399,7 +419,8 @@ mod tests {
         let (e, id) = setup();
         let c = client(&e, &id);
         let admin = soroban_sdk::Address::generate(&e);
-        c.initialize(&soroban_sdk::vec![&e], &1, &admin);
+        let signer = soroban_sdk::Address::generate(&e);
+        c.initialize(&soroban_sdk::vec![&e, (signer.clone(), 1u64)], &1, &admin);
         let result = c.get_pending_settlements(&None, &None);
         assert_eq!(result.len(), 0);
     }
@@ -540,7 +561,8 @@ mod tests {
         let c = client(&e, &id);
         let admin = soroban_sdk::Address::generate(&e);
         let signer = soroban_sdk::Address::generate(&e);
-        c.initialize(&soroban_sdk::vec![&e], &1, &admin);
+        let initial = soroban_sdk::Address::generate(&e);
+        c.initialize(&soroban_sdk::vec![&e, (initial.clone(), 1u64)], &1, &admin);
         c.pause(&admin);
         let res = c.try_set_signer(&admin, &signer, &1u64);
         assert_eq!(res, Err(Ok(TreasuryError::ContractPaused)));
@@ -551,7 +573,8 @@ mod tests {
         let (e, id) = setup();
         let c = client(&e, &id);
         let admin = soroban_sdk::Address::generate(&e);
-        c.initialize(&soroban_sdk::vec![&e], &1, &admin);
+        let signer = soroban_sdk::Address::generate(&e);
+        c.initialize(&soroban_sdk::vec![&e, (signer.clone(), 1u64)], &1, &admin);
         c.pause(&admin);
         let res = c.try_update_threshold(&admin, &2u32);
         assert_eq!(res, Err(Ok(TreasuryError::ContractPaused)));
@@ -564,15 +587,22 @@ mod tests {
         let (e, id) = setup();
         let c = client(&e, &id);
         let admin = soroban_sdk::Address::generate(&e);
-        let signer = soroban_sdk::Address::generate(&e);
+        let s1 = soroban_sdk::Address::generate(&e);
+        let s2 = soroban_sdk::Address::generate(&e);
+        let s3 = soroban_sdk::Address::generate(&e);
         let token = soroban_sdk::Address::generate(&e);
         let merchant = soroban_sdk::Address::generate(&e);
-        // threshold=3, signer weight=1 → approval_weight after approve = 1 < 3
-        c.initialize(&soroban_sdk::vec![&e, (signer.clone(), 1u64)], &3, &admin);
-        let sid = c.propose_settlement(&signer, &token, &500u64, &merchant);
-        c.approve_settlement(&signer, &sid);
+        // threshold=3, each signer weight=1 → total weight=3 >= 3 (valid init)
+        // After s1 approves: approval_weight=1 < 3
+        c.initialize(
+            &soroban_sdk::vec![&e, (s1.clone(), 1u64), (s2.clone(), 1u64), (s3.clone(), 1u64)],
+            &3,
+            &admin,
+        );
+        let sid = c.propose_settlement(&s1, &token, &500u64, &merchant);
+        c.approve_settlement(&s1, &sid);
         // execute should fail with InsufficientApprovals
-        let res = c.try_execute_settlement(&signer, &sid, &token);
+        let res = c.try_execute_settlement(&s1, &sid, &token);
         assert_eq!(res, Err(Ok(TreasuryError::InsufficientApprovals)));
         // settlement must still be Pending
         let pending = c.get_pending_settlements(&None, &None);
@@ -619,7 +649,8 @@ mod tests {
         let (e, id) = setup();
         let c = client(&e, &id);
         let admin = soroban_sdk::Address::generate(&e);
-        c.initialize(&soroban_sdk::vec![&e], &1, &admin);
+        let signer = soroban_sdk::Address::generate(&e);
+        c.initialize(&soroban_sdk::vec![&e, (signer.clone(), 1u64)], &1, &admin);
         let res = c.try_update_threshold(&admin, &0u32);
         assert_eq!(res, Err(Ok(TreasuryError::InvalidThreshold)));
     }

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -35,6 +35,8 @@ pub enum SettlementError {
     Unauthorized = 2,
     AlreadyApproved = 3,
     NotPending = 4,
+    DuplicateSigner = 5,
+    InvalidWeightSum = 6,
 }
 
 #[contracttype]
@@ -51,7 +53,23 @@ pub struct SettlementContract;
 #[contractimpl]
 impl SettlementContract {
     /// Initialize with signers (address, weight pairs) and approval threshold.
-    pub fn initialize(e: Env, signers: Vec<(Address, u64)>, threshold: u64) {
+    pub fn initialize(
+        e: Env,
+        signers: Vec<(Address, u64)>,
+        threshold: u64,
+    ) -> Result<(), SettlementError> {
+        let mut seen: Vec<Address> = Vec::new(&e);
+        let mut total_weight: u64 = 0;
+        for (signer, weight) in signers.iter() {
+            if seen.contains(&signer) {
+                return Err(SettlementError::DuplicateSigner);
+            }
+            seen.push_back(signer.clone());
+            total_weight += weight;
+        }
+        if total_weight < threshold {
+            return Err(SettlementError::InvalidWeightSum);
+        }
         e.storage().instance().set(&DataKey::Threshold, &threshold);
         e.storage().instance().set(&DataKey::NextId, &1u64);
         for (signer, weight) in signers.iter() {
@@ -59,6 +77,7 @@ impl SettlementContract {
                 .instance()
                 .set(&DataKey::Signer(signer.clone()), &weight);
         }
+        Ok(())
     }
 
     /// Propose a new settlement; returns the settlement ID.
@@ -177,12 +196,12 @@ mod tests {
         let signer = Address::generate(&e);
         let merchant = Address::generate(&e);
 
-        c.initialize(&soroban_sdk::vec![&e, (signer.clone(), 2u64)], &3u64);
+        c.initialize(&soroban_sdk::vec![&e, (signer.clone(), 2u64)], &2u64);
         let sid = c.propose(&signer, &merchant, &1000u64);
 
         let res = c.approve_settlement(&signer, &sid);
         assert_eq!(res.approval_weight, 2);
-        assert_eq!(res.threshold, 3);
+        assert_eq!(res.threshold, 2);
     }
 
     #[test]
@@ -207,7 +226,7 @@ mod tests {
         let signer = Address::generate(&e);
         let merchant = Address::generate(&e);
 
-        c.initialize(&soroban_sdk::vec![&e, (signer.clone(), 1u64)], &2u64);
+        c.initialize(&soroban_sdk::vec![&e, (signer.clone(), 1u64)], &1u64);
         let sid = c.propose(&signer, &merchant, &100u64);
 
         c.approve_settlement(&signer, &sid);


### PR DESCRIPTION
Add validation to `SettlementContract::initialize` and `TreasuryContract::initialize` to reject initialization when:
- The sum of signer weights is less than the threshold (prevents deploying an un-approvable treasury)
- Duplicate signer addresses are provided in the same call

Both functions now return `Result<(), Error>` instead of `()` to surface these validation errors.

Closes #167
Closes #168
Closes #169
Closes #170