### PR TITLE
chore: document the two contract trees

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,3 +1,12 @@
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  MIRRORED / DEPRECATED TREE                                 ║
+# ║  This workspace is an older in-tree copy of the canonical    ║
+# ║  COMEBACKHERE-contracts/ workspace. It exists only for       ║
+# ║  backward-compatible doc references and review familiarity.  ║
+# ║                                                              ║
+# ║  → All new contract work MUST target COMEBACKHERE-contracts/ ║
+# ║  → See ARCHITECTURE.md for the full rationale                ║
+# ╚══════════════════════════════════════════════════════════════╝
 [workspace]
 members = [
     "invoice",


### PR DESCRIPTION
## Description

This PR documents the relationship between the two parallel contract source trees in this repository (`contracts/` and `COMEBACKHERE-contracts/`).

## Changes

- Added a deprecation marker at the top of `contracts/Cargo.toml` clearly indicating it is a mirrored older copy
- The `ARCHITECTURE.md` and `CONTRIBUTING.md` already exist and explain which tree is canonical

The `contracts/` tree is an older in-tree copy of the canonical `COMEBACKHERE-contracts/` workspace, kept for backward-compatible doc references. All new contract work must target `COMEBACKHERE-contracts/`.

Closes #181