### PR TITLE
feat: add paginated GET /invoices endpoint with caching

### DIFF
--- a/comebackhere-backend/src/app.ts
+++ b/comebackhere-backend/src/app.ts
@@ -9,6 +9,7 @@ import thresholdRouter from "./routes/threshold.js"
 import disputesRouter from "./routes/disputes.js"
 import analyticsRouter from "./routes/analytics.js"
 import { rateLimitMiddleware } from "./middleware/rateLimiter.js"
+import { correlationIdMiddleware } from "./middleware/correlationId.js"
 import { openapiSpec } from "./openapi.js"
 
 export function createApp() {

--- a/comebackhere-backend/src/db/mongo.ts
+++ b/comebackhere-backend/src/db/mongo.ts
@@ -1,5 +1,18 @@
 import { MongoClient, type Db, type Collection } from "mongodb"
 
+export type InvoiceStatus = "Pending" | "Paid" | "Expired" | "Cancelled" | "RefundRequested" | "Released"
+
+export interface InvoiceRecord {
+  invoice_id: string
+  merchant_address: string
+  token: string
+  amount: number
+  due_date: number
+  status: InvoiceStatus
+  created_at: Date
+  updated_at: Date
+}
+
 export interface SettlementRecord {
   id: number
   merchant_address: string
@@ -40,10 +53,20 @@ export async function connectMongo(): Promise<Db> {
   await settlements.createIndex({ id: 1 }, { unique: true })
   await settlements.createIndex({ status: 1 })
 
+  const invoices = db.collection<InvoiceRecord>("invoices")
+  await invoices.createIndex({ invoice_id: 1 }, { unique: true })
+  await invoices.createIndex({ status: 1 })
+  await invoices.createIndex({ merchant_address: 1 })
+  await invoices.createIndex({ status: 1, merchant_address: 1 })
+
   const cursors = db.collection<IndexerCursor>("indexer_cursors")
   await cursors.createIndex({ _id: 1 }, { unique: true })
 
   return db
+}
+
+export function getInvoicesCollection(database: Db): Collection<InvoiceRecord> {
+  return database.collection<InvoiceRecord>("invoices")
 }
 
 export function getSettlementsCollection(database: Db): Collection<SettlementRecord> {

--- a/comebackhere-backend/src/lib/cache.ts
+++ b/comebackhere-backend/src/lib/cache.ts
@@ -1,0 +1,37 @@
+import Redis from "ioredis"
+
+let _redis: Redis | null = null
+
+function getRedis(): Redis | null {
+  if (_redis) return _redis
+  const redisUrl = process.env.REDIS_URL
+  if (!redisUrl) return null
+  _redis = new Redis(redisUrl, { lazyConnect: true })
+  _redis.on("error", () => {})
+  return _redis
+}
+
+export function resetRedis(): void {
+  _redis = null
+}
+
+export async function cacheGet<T>(key: string): Promise<T | null> {
+  const redis = getRedis()
+  if (!redis) return null
+  try {
+    const raw = await redis.get(key)
+    return raw ? (JSON.parse(raw) as T) : null
+  } catch {
+    return null
+  }
+}
+
+export async function cacheSet(key: string, value: unknown, ttlSec = 30): Promise<void> {
+  const redis = getRedis()
+  if (!redis) return
+  try {
+    await redis.setex(key, ttlSec, JSON.stringify(value))
+  } catch {
+    // silently fail – cache is optional
+  }
+}

--- a/comebackhere-backend/src/routes/invoices.ts
+++ b/comebackhere-backend/src/routes/invoices.ts
@@ -1,5 +1,7 @@
 import { Router, type Request, type Response } from "express"
 import { Keypair, Networks, TransactionBuilder, BASE_FEE, Contract, nativeToScVal, SorobanRpc, xdr } from "stellar-sdk"
+import { connectMongo, getInvoicesCollection, type InvoiceRecord, type InvoiceStatus } from "../db/mongo.js"
+import { cacheGet, cacheSet } from "../lib/cache.js"
 
 const router = Router()
 
@@ -122,6 +124,107 @@ export async function createInvoice(
 
   return { invoice_id: invoiceId, status: "Pending" }
 }
+
+/**
+ * @openapi
+ * /invoices:
+ *   get:
+ *     tags: [Invoices]
+ *     summary: List invoices with pagination and filtering
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [Pending, Paid, Expired, Cancelled, RefundRequested, Released]
+ *       - in: query
+ *         name: merchant
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Paginated invoice list
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Invoice'
+ *                 total:
+ *                   type: integer
+ *                 page:
+ *                   type: integer
+ *                 limit:
+ *                   type: integer
+ *                 totalPages:
+ *                   type: integer
+ */
+router.get("/", async (req: Request, res: Response) => {
+  const page = Math.max(1, parseInt(req.query.page as string, 10) || 1)
+  const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string, 10) || 20))
+  const statusFilter = req.query.status as string | undefined
+  const merchantFilter = req.query.merchant as string | undefined
+
+  const allowedStatuses: InvoiceStatus[] = ["Pending", "Paid", "Expired", "Cancelled", "RefundRequested", "Released"]
+  const status = statusFilter && allowedStatuses.includes(statusFilter as InvoiceStatus)
+    ? (statusFilter as InvoiceStatus)
+    : undefined
+
+  const cacheKey = `invoices:${page}:${limit}:${status ?? "all"}:${merchantFilter ?? "all"}`
+
+  const cached = await cacheGet<{ data: InvoiceRecord[]; total: number; page: number; limit: number; totalPages: number }>(cacheKey)
+  if (cached) {
+    res.json(cached)
+    return
+  }
+
+  try {
+    const db = await connectMongo()
+    const collection = getInvoicesCollection(db)
+
+    const filter: Record<string, unknown> = {}
+    if (status) filter.status = status
+    if (merchantFilter) filter.merchant_address = merchantFilter
+
+    const total = await collection.countDocuments(filter)
+    const totalPages = Math.ceil(total / limit)
+    const skip = (page - 1) * limit
+
+    const data = await collection
+      .find(filter)
+      .sort({ created_at: -1 })
+      .skip(skip)
+      .limit(limit)
+      .toArray()
+
+    const result = {
+      data,
+      total,
+      page,
+      limit,
+      totalPages,
+    }
+
+    await cacheSet(cacheKey, result, 30)
+    res.json(result)
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    res.status(500).json({ error: message })
+  }
+})
 
 /**
  * @openapi
@@ -310,6 +413,22 @@ router.post("/", async (req: Request, res: Response) => {
       signerSecret,
       networkPassphrase
     )
+
+    const db = await connectMongo()
+    const collection = getInvoicesCollection(db)
+    const body = req.body as CreateInvoiceBody
+    const now = new Date()
+    await collection.insertOne({
+      invoice_id: result.invoice_id,
+      merchant_address: body.merchant_address,
+      token: body.token,
+      amount: body.amount,
+      due_date: body.due_date,
+      status: "Pending",
+      created_at: now,
+      updated_at: now,
+    })
+
     res.status(201).json(result)
   } catch (err: unknown) {
     const status = (err as any)?.status ?? 500


### PR DESCRIPTION
## Changes
Closes #321
Closes #327

- Added paginated GET /invoices endpoint with page, limit, status, merchant query params
- Returns { data, total, page, limit, totalPages } response format
- Stores invoice records in MongoDB invoices collection on creation
- Added Redis-based caching layer (lib/cache.ts) with configurable TTL
- Added InvoiceRecord interface and compound MongoDB indexes
- Fixed missing correlationIdMiddleware import in app.ts

## Testing

All 95 backend tests pass (10 test files).