### PR TITLE
fix(frontend): surface open disputes on InvoicePayment, stop polling timer while hidden

### DIFF
--- a/comebackhere-frontend/src/App.css
+++ b/comebackhere-frontend/src/App.css
@@ -347,6 +347,12 @@ h3 {
   color: var(--color-success);
 }
 
+.message--warning {
+  background: var(--color-warning-bg);
+  border: 1px solid var(--color-warning-text);
+  color: var(--color-warning-text);
+}
+
 .tx-hash {
   font-family: monospace;
   font-size: 0.85rem;

--- a/comebackhere-frontend/src/components/InvoicePayment.tsx
+++ b/comebackhere-frontend/src/components/InvoicePayment.tsx
@@ -119,6 +119,8 @@ export function InvoicePayment() {
 
   const canCancel = isMerchant && invoice?.status === "Pending"
 
+  const hasOpenDispute = invoice?.status === "RefundRequested"
+
   return (
     <div className="payment-flow">
       <h1>Invoice Payment</h1>
@@ -172,6 +174,15 @@ export function InvoicePayment() {
             <h2>Invoice #<CopyableText text={String(invoice.id)} label="Copy invoice ID" /></h2>
             <StatusBadge status={invoice.status} />
           </div>
+
+          {hasOpenDispute && (
+            <div className="message message--warning" role="status" aria-live="polite">
+              <strong>Dispute in progress.</strong> A refund has been requested for this
+              invoice, which opens an escrow dispute and holds the funds. Payment,
+              cancellation, and escrow release are unavailable until the dispute is
+              resolved.
+            </div>
+          )}
 
           <div className="invoice-card__body">
             <div className="detail-row">
@@ -236,7 +247,7 @@ export function InvoicePayment() {
               </button>
             )}
 
-            {connected && invoice.status !== "Pending" && (
+            {connected && invoice.status !== "Pending" && !hasOpenDispute && (
               <p className="status-text">
                 This invoice is not available for payment
                 (status: {invoice.status}).

--- a/comebackhere-frontend/src/hooks/usePolling.ts
+++ b/comebackhere-frontend/src/hooks/usePolling.ts
@@ -54,18 +54,33 @@ export function usePolling(
     // Fire once immediately when enabled / address changes.
     runPoll()
 
-    const id = setInterval(runPoll, interval)
+    let id: ReturnType<typeof setInterval> | null = null
+    const startInterval = () => {
+      if (id === null) id = setInterval(runPoll, interval)
+    }
+    const stopInterval = () => {
+      if (id !== null) {
+        clearInterval(id)
+        id = null
+      }
+    }
 
-    // Pause/resume on visibility change.
+    // Only tick while the tab is visible; tearing the timer down entirely
+    // while hidden avoids waking up on every interval just to no-op.
+    if (!document.hidden) startInterval()
+
     const handleVisibilityChange = () => {
-      if (!document.hidden) {
+      if (document.hidden) {
+        stopInterval()
+      } else {
         runPoll()
+        startInterval()
       }
     }
     document.addEventListener("visibilitychange", handleVisibilityChange)
 
     return () => {
-      clearInterval(id)
+      stopInterval()
       document.removeEventListener("visibilitychange", handleVisibilityChange)
     }
   }, [enabled, interval, runPoll])

--- a/comebackhere-frontend/src/tests/InvoicePayment.test.tsx
+++ b/comebackhere-frontend/src/tests/InvoicePayment.test.tsx
@@ -322,6 +322,32 @@ describe("InvoicePayment — confirmation modals", () => {
   })
 })
 
+describe("InvoicePayment — open dispute", () => {
+  it("shows a dispute notice instead of the generic status text when RefundRequested", () => {
+    mockUseWallet.connected = true
+    mockUseInvoice.invoice = { ...mockInvoice, status: "RefundRequested" }
+    render(<InvoicePayment />)
+    expect(screen.getByText(/dispute in progress/i)).toBeInTheDocument()
+    expect(screen.queryByText(/not available for payment/i)).not.toBeInTheDocument()
+  })
+
+  it("does not show a dispute notice for other non-pending statuses", () => {
+    mockUseWallet.connected = true
+    mockUseInvoice.invoice = { ...mockInvoice, status: "Paid" }
+    render(<InvoicePayment />)
+    expect(screen.queryByText(/dispute in progress/i)).not.toBeInTheDocument()
+  })
+
+  it("hides pay and cancel actions while a dispute is open", () => {
+    mockUseWallet.connected = true
+    mockUseWallet.address = mockInvoice.merchant
+    mockUseInvoice.invoice = { ...mockInvoice, status: "RefundRequested" }
+    render(<InvoicePayment />)
+    expect(screen.queryByRole("button", { name: /pay invoice/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /cancel invoice/i })).not.toBeInTheDocument()
+  })
+})
+
 describe("InvoicePayment — connect button disabled while connecting", () => {
   it("shows connecting state", () => {
     mockUseWallet.connecting = true

--- a/comebackhere-frontend/src/tests/usePolling.test.ts
+++ b/comebackhere-frontend/src/tests/usePolling.test.ts
@@ -157,6 +157,41 @@ describe("usePolling", () => {
     expect(result.current.lastUpdatedAt).toBeNull()
   })
 
+  it("does not fire twice in quick succession when the tab becomes visible right before an interval tick", async () => {
+    const callback = vi.fn().mockResolvedValue(undefined)
+    renderHook(() => usePolling(callback, { interval: 5_000, enabled: true }))
+
+    await tick()        // call 1 (immediate, visible)
+    await tick(4_000)   // 1s away from the next scheduled tick
+
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => true,
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"))
+      await Promise.resolve()
+    })
+
+    // Tab hidden: the old interval must be torn down, so advancing well past
+    // the original schedule should not produce another call.
+    await tick(10_000)
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => false,
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"))
+      await Promise.resolve()
+    })
+
+    // Resuming triggers exactly one immediate poll, not a duplicate from a
+    // stale interval landing around the same time.
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
   it("polls multiple intervals correctly", async () => {
     const callback = vi.fn().mockResolvedValue(undefined)
     renderHook(() => usePolling(callback, { interval: 5_000, enabled: true }))


### PR DESCRIPTION
## Summary



 Open disputes weren't surfaced to the payer**
`InvoicePayment` had no dedicated handling for an invoice with an open dispute — it fell into the same generic "This invoice is not available for payment (status: X)" text as any other non-pending status, giving the payer no explanation for why payment/cancellation/release were blocked.

Investigation found there is no separate `Disputed` status anywhere in this codebase — not in the frontend `InvoiceStatus` type, either backend, or either Soroban contract tree. The only real, wired-up per-invoice signal for "an open dispute" is `InvoiceStatus.RefundRequested`, which `RefundConfirmationModal`'s own copy already describes as initiating "the escrow dispute process." So this fix special-cases that status with a clear, dedicated notice instead of inventing new (unbacked) state.

- Added a `message--warning` banner in `InvoicePayment.tsx`, shown whenever `invoice.status === "RefundRequested"`, explaining that a dispute is open, funds are held in escrow, and why payment/cancellation/release are unavailable.
- Suppressed the old generic fallback text for this case so the two messages don't show side by side.
- Added a `.message--warning` style in `App.css`, reusing the existing warning color tokens (already theme-aware for light/dark).

 `usePolling` kept a background timer ticking while the tab was hidden**
The hook already skipped the actual poll callback while `document.hidden` was true, so no wasted network requests were happening — but the underlying `setInterval` kept firing every interval regardless, waking up only to no-op. Tightened this so the interval is torn down entirely on hide and cleanly restarted (with an immediate poll) on resume, eliminating background timer activity and avoiding a possible duplicate poll if a stale interval landed right around a visibility-resume event.

## Test plan

- [x] `npx vitest run` — full suite passes (130/130)
- [x] `npx tsc --noEmit` — clean
- [x] New tests added:
  - `InvoicePayment.test.tsx`: dispute banner shown for `RefundRequested`, not shown for other non-pending statuses, pay/cancel actions stay hidden during a dispute
  - `usePolling.test.ts`: no duplicate/extra poll when the tab is hidden then resumed near a scheduled tick
  
  closes #445 
  closes #446 
  closes #444 
  closes #447 