### PR TITLE
test: expand rate limiter test coverage in rust backend

### DIFF
--- a/backend/src/rate_limiter.rs
+++ b/backend/src/rate_limiter.rs
@@ -224,6 +224,21 @@ mod tests {
     use super::*;
     use axum::{routing::get, Router};
     use axum_test::TestServer;
+    use std::sync::{Mutex, OnceLock};
+
+    /// Serialises tests that mutate the process-wide environment so they don't
+    /// race with one another when run in parallel.
+    fn env_guard() -> &'static Mutex<()> {
+        static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+        GUARD.get_or_init(|| Mutex::new(()))
+    }
+
+    fn restore_env(key: &str, value: Option<String>) {
+        match value {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
 
     fn make_server(max_requests: u64, window_secs: u64) -> TestServer {
         let config = RateLimitConfig {
@@ -376,5 +391,120 @@ mod tests {
             StatusCode::TOO_MANY_REQUESTS,
             "different IP should have its own independent bucket"
         );
+    }
+
+    // ── extract_ip ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_extract_ip_takes_first_trimmed_ip_from_comma_list() {
+        use axum::http::header::{HeaderName, HeaderValue};
+        let mut req = Request::new(Body::from(""));
+        req.headers_mut().insert(
+            HeaderName::from_static("x-forwarded-for"),
+            HeaderValue::from_static("1.2.3.4, 5.6.7.8, 9.9.9.9"),
+        );
+        assert_eq!(extract_ip(&req), "1.2.3.4");
+    }
+
+    #[test]
+    fn test_extract_ip_trims_whitespace_in_first_entry() {
+        use axum::http::header::{HeaderName, HeaderValue};
+        let mut req = Request::new(Body::from(""));
+        req.headers_mut().insert(
+            HeaderName::from_static("x-forwarded-for"),
+            HeaderValue::from_static("  10.0.0.1  , 192.168.0.2"),
+        );
+        assert_eq!(extract_ip(&req), "10.0.0.1");
+    }
+
+    #[test]
+    fn test_extract_ip_falls_back_to_connect_info_without_xff() {
+        let mut req = Request::new(Body::from(""));
+        let addr: SocketAddr = "203.0.113.9:1234".parse().unwrap();
+        req.extensions_mut().insert(ConnectInfo(addr));
+        assert_eq!(extract_ip(&req), "203.0.113.9");
+    }
+
+    #[test]
+    fn test_extract_ip_skips_empty_xff_and_uses_connect_info() {
+        use axum::http::header::{HeaderName, HeaderValue};
+        let mut req = Request::new(Body::from(""));
+        req.headers_mut().insert(
+            HeaderName::from_static("x-forwarded-for"),
+            HeaderValue::from_static("   "),
+        );
+        let addr: SocketAddr = "198.51.100.7:9999".parse().unwrap();
+        req.extensions_mut().insert(ConnectInfo(addr));
+        assert_eq!(extract_ip(&req), "198.51.100.7");
+    }
+
+    #[test]
+    fn test_extract_ip_returns_unknown_without_xff_or_connect_info() {
+        let req = Request::new(Body::from(""));
+        assert_eq!(extract_ip(&req), "unknown");
+    }
+
+    // ── Bucket rolling window ───────────────────────────────────────────────
+
+    #[test]
+    fn test_bucket_sliding_window_purges_stale_and_rolls() {
+        let t0 = Instant::now();
+        let window = Duration::from_millis(100);
+        let mut bucket = Bucket::new();
+
+        // Two requests inside the window are allowed (max = 3).
+        assert!(bucket.check_and_record(t0, window, 3).0);
+        assert!(bucket.check_and_record(t0 + Duration::from_millis(50), window, 3).0);
+
+        // A third request still inside the window fills the bucket → blocked.
+        assert!(!bucket.check_and_record(t0 + Duration::from_millis(60), window, 3).0);
+
+        // After t0 + window, the first entries expire, so a slot frees up and
+        // the rolling window allows the request again.
+        assert!(bucket.check_and_record(t0 + Duration::from_millis(150), window, 3).0);
+    }
+
+    // ── from_env ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_from_env_parses_points_and_duration() {
+        let _guard = env_guard().lock().unwrap();
+        let old_points = std::env::var("RATE_LIMIT_POINTS").ok();
+        let old_duration = std::env::var("RATE_LIMIT_DURATION").ok();
+        std::env::set_var("RATE_LIMIT_POINTS", "120");
+        std::env::set_var("RATE_LIMIT_DURATION", "30");
+        let cfg = RateLimitConfig::from_env();
+        restore_env("RATE_LIMIT_POINTS", old_points);
+        restore_env("RATE_LIMIT_DURATION", old_duration);
+        assert_eq!(cfg.max_requests, 120);
+        assert_eq!(cfg.window, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_from_env_uses_defaults_when_unset() {
+        let _guard = env_guard().lock().unwrap();
+        let old_points = std::env::var("RATE_LIMIT_POINTS").ok();
+        let old_duration = std::env::var("RATE_LIMIT_DURATION").ok();
+        std::env::remove_var("RATE_LIMIT_POINTS");
+        std::env::remove_var("RATE_LIMIT_DURATION");
+        let cfg = RateLimitConfig::from_env();
+        restore_env("RATE_LIMIT_POINTS", old_points);
+        restore_env("RATE_LIMIT_DURATION", old_duration);
+        assert_eq!(cfg.max_requests, 60);
+        assert_eq!(cfg.window, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_from_env_ignores_invalid_values_and_uses_defaults() {
+        let _guard = env_guard().lock().unwrap();
+        let old_points = std::env::var("RATE_LIMIT_POINTS").ok();
+        let old_duration = std::env::var("RATE_LIMIT_DURATION").ok();
+        std::env::set_var("RATE_LIMIT_POINTS", "not-a-number");
+        std::env::set_var("RATE_LIMIT_DURATION", "abc");
+        let cfg = RateLimitConfig::from_env();
+        restore_env("RATE_LIMIT_POINTS", old_points);
+        restore_env("RATE_LIMIT_DURATION", old_duration);
+        assert_eq!(cfg.max_requests, 60);
+        assert_eq!(cfg.window, Duration::from_secs(60));
     }
 }


### PR DESCRIPTION
Closes #430
Closes #431
Closes #432
Closes #433

# Pull Request

## Summary

- The legacy Rust/Axum backend (`backend/`) protects the same class of endpoints as the canonical TypeScript backend, but its rate limiter test coverage lagged behind the TypeScript suite (`comebackhere-backend/src/tests/rateLimiter.test.ts`). While `backend/src/rate_limiter.rs` gained a basic `#[cfg(test)]` module when the middleware was introduced, several code paths were never exercised: IP extraction from comma-separated `X-Forwarded-For`, the `ConnectInfo`/`"unknown"` fallbacks, the sliding-window purge behaviour, and `RATE_LIMIT_POINTS`/`RATE_LIMIT_DURATION` env parsing.
- This PR brings the Rust suite up to parity with the TypeScript one so anyone running the legacy backend gets the same guarantees (429 + `Retry-After` + JSON body, per-IP buckets, config parsing) with the same confidence.

## Changes

All additions live in the existing `#[cfg(test)] mod tests` block of `backend/src/rate_limiter.rs`; no production code is touched.

- **`extract_ip` unit tests** — first IP of a comma-separated `X-Forwarded-For` list, whitespace trimming, fallback to `ConnectInfo<SocketAddr>` when `X-Forwarded-For` is absent or blank, and `"unknown"` when neither is present.
- **`Bucket` sliding-window test** — verifies stale timestamps are purged so a slot frees up as the window rolls (contrast to fixed-window reset semantics).
- **`RateLimitConfig::from_env()` tests** — parses valid `RATE_LIMIT_POINTS`/`RATE_LIMIT_DURATION`, falls back to 60/60 defaults when unset or non-numeric (serialised via a static mutex since env vars are process-global).

## Checklist

- [ ] Closes #__ (n/a — no linked issue)
- [x] Tests added or updated
- [ ] ABI snapshot updated if contract sources changed (`abis/` and `COMEBACKHERE-contracts/`) — n/a
- [ ] Screenshots attached if UI changed — n/a
- [ ] Documentation updated if needed — n/a

## Notes

- `cargo` was not available in the authoring environment, so `cargo test -p comebackhere-backend` (from `backend/`) has **not** been run here. The new tests are synchronous `#[test]` functions that follow the module's existing `axum-test` patterns; please run the suite to confirm.
- CI gap worth flagging: `.github/workflows/backend-tests.yml` currently only runs the `contracts/` crate, so tests in `backend/` are not part of the required status checks. Adding a job for this crate would be a natural follow-up.
