### PR TITLE
feat: serve /.well-known/security.txt from the frontend

### DIFF
--- a/comebackhere-frontend/public/.well-known/security.txt
+++ b/comebackhere-frontend/public/.well-known/security.txt
@@ -1,0 +1,7 @@
+Contact: mailto:security@comebackhere.io
+Contact: https://github.com/WHEELBACK/COMEBACKHERE/blob/main/SECURITY.md
+Encryption: https://comebackhere.io/.well-known/pgp-key.txt
+Expires: 2027-08-27T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://comebackhere.io/.well-known/security.txt
+Policy: https://github.com/WHEELBACK/COMEBACKHERE/blob/main/SECURITY.md


### PR DESCRIPTION
## Summary

Adds the machine-readable `/.well-known/security.txt` endpoint (RFC 9116) to the frontend so security researchers and automated scanners probing a live deployment immediately discover the project's coordinated-disclosure process instead of hitting a dead path.

The file is placed at the Vite static root (`public/.well-known/security.txt`), so `npm run build` copies it to the root of the served bundle at `/.well-known/security.txt`. It mirrors the contact, PGP encryption, and policy details already documented in `SECURITY.md` (#88).

Closes #509
Closes #511
Closes #503
Closes #502