### PR TITLE
feat: forward correlation ID (X-Request-Id) on outbound webhook deliveries

### DIFF
--- a/comebackhere-backend/src/services/webhook-delivery.ts
+++ b/comebackhere-backend/src/services/webhook-delivery.ts
@@ -7,6 +7,11 @@
  *
  * Idempotency: every payload includes an `idempotency_key` so the merchant can
  * detect duplicate deliveries caused by retries.
+ *
+ * Correlation: when a correlation ID is supplied (e.g. `res.locals.requestId`
+ * from the correlationId middleware, issue #224), it is forwarded as an
+ * `X-Request-Id` header on every delivery attempt so the merchant can trace a
+ * single event across both the backend and their own logs.
  */
 
 // ---------------------------------------------------------------------------
@@ -37,6 +42,8 @@ export interface WebhookDeliveryRecord {
   last_attempt_at: string | null
   last_status_code: number | null
   last_error: string | null
+  /** Correlation ID forwarded as `X-Request-Id`, or null when none was supplied. */
+  request_id: string | null
 }
 
 // ---------------------------------------------------------------------------
@@ -56,23 +63,32 @@ export const BASE_DELAY_MS = 1_000
  * or throws on network error / timeout.
  *
  * Swappable via the `fetchFn` parameter so tests can inject a fake.
+ *
+ * @param correlationId Correlation ID forwarded as the `X-Request-Id` header
+ *                      (e.g. `res.locals.requestId`). Omitted when undefined.
  */
 export async function postWebhook(
   endpoint: string,
   payload: WebhookPayload,
   fetchFn: typeof fetch = fetch,
   timeoutMs = 10_000,
+  correlationId?: string,
 ): Promise<number> {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-Idempotency-Key": payload.idempotency_key,
+  }
+  if (correlationId && correlationId.trim() !== "") {
+    headers["X-Request-Id"] = correlationId
+  }
+
   try {
     const response = await fetchFn(endpoint, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Idempotency-Key": payload.idempotency_key,
-      },
+      headers,
       body: JSON.stringify(payload),
       signal: controller.signal,
     })
@@ -102,6 +118,9 @@ export function defaultDelay(ms: number): Promise<void> {
  * @param maxAttempts   Hard cap on delivery attempts (default: 5).
  * @param fetchFn       Fetch implementation (injectable for tests).
  * @param delayFn       Sleep implementation (injectable for tests).
+ * @param correlationId Correlation ID forwarded as the `X-Request-Id` header on
+ *                      every attempt (e.g. `res.locals.requestId`). Preserved
+ *                      across retries and recorded on the delivery record.
  * @returns             A delivery record describing the final outcome.
  */
 export async function deliverWebhook(
@@ -110,6 +129,7 @@ export async function deliverWebhook(
   maxAttempts = DEFAULT_MAX_ATTEMPTS,
   fetchFn: typeof fetch = fetch,
   delayFn: (ms: number) => Promise<void> = defaultDelay,
+  correlationId?: string,
 ): Promise<WebhookDeliveryRecord> {
   const record: WebhookDeliveryRecord = {
     idempotency_key: payload.idempotency_key,
@@ -120,6 +140,7 @@ export async function deliverWebhook(
     last_attempt_at: null,
     last_status_code: null,
     last_error: null,
+    request_id: correlationId ?? null,
   }
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -127,7 +148,7 @@ export async function deliverWebhook(
     record.last_attempt_at = new Date().toISOString()
 
     try {
-      const statusCode = await postWebhook(endpoint, payload, fetchFn)
+      const statusCode = await postWebhook(endpoint, payload, fetchFn, undefined, correlationId)
       record.last_status_code = statusCode
 
       if (statusCode >= 200 && statusCode < 300) {
@@ -154,7 +175,8 @@ export async function deliverWebhook(
   record.status = "failed"
   console.error(
     `[webhook] delivery failed after ${record.attempts} attempt(s) ` +
-    `key=${record.idempotency_key} endpoint=${endpoint} last_error=${record.last_error}`,
+    `key=${record.idempotency_key} requestId=${record.request_id ?? "-"} ` +
+    `endpoint=${endpoint} last_error=${record.last_error}`,
   )
   return record
 }

--- a/comebackhere-backend/src/tests/webhook-delivery.test.ts
+++ b/comebackhere-backend/src/tests/webhook-delivery.test.ts
@@ -174,6 +174,54 @@ describe("deliverWebhook", () => {
     expect(capturedHeaders[1]["X-Idempotency-Key"]).toBe("invoice_paid:7")
   })
 
+  it("forwards X-Request-Id on every attempt when a correlationId is supplied", async () => {
+    const capturedHeaders: Record<string, string>[] = []
+    const fetchFn = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      capturedHeaders.push((init?.headers ?? {}) as Record<string, string>)
+      return { status: 500 } as Response
+    }) as unknown as typeof fetch
+
+    const payload = makePayload()
+
+    await deliverWebhook("https://example.com/hook", payload, 3, fetchFn, noDelay, "trace-abc-123")
+
+    expect(capturedHeaders).toHaveLength(3)
+    expect(capturedHeaders.every((h) => h["X-Request-Id"] === "trace-abc-123")).toBe(true)
+  })
+
+  it("omits X-Request-Id when no correlationId is supplied", async () => {
+    const capturedHeaders: Record<string, string>[] = []
+    const fetchFn = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      capturedHeaders.push((init?.headers ?? {}) as Record<string, string>)
+      return { status: 200 } as Response
+    }) as unknown as typeof fetch
+
+    const payload = makePayload()
+
+    await deliverWebhook("https://example.com/hook", payload, 2, fetchFn, noDelay)
+
+    expect(capturedHeaders).toHaveLength(1)
+    expect(capturedHeaders[0]["X-Request-Id"]).toBeUndefined()
+  })
+
+  it("records the correlationId as request_id in the delivery record", async () => {
+    const fetchFn = makeFetch([{ status: 200 }])
+    const payload = makePayload()
+
+    const record = await deliverWebhook("https://example.com/hook", payload, 5, fetchFn, noDelay, "trace-xyz-789")
+
+    expect(record.request_id).toBe("trace-xyz-789")
+  })
+
+  it("records request_id as null when no correlationId is supplied", async () => {
+    const fetchFn = makeFetch([{ status: 503 }])
+    const payload = makePayload()
+
+    const record = await deliverWebhook("https://example.com/hook", payload, 1, fetchFn, noDelay)
+
+    expect(record.request_id).toBeNull()
+  })
+
   it("records the last HTTP status code in the delivery record", async () => {
     const fetchFn = makeFetch([{ status: 404 }, { status: 429 }, { status: 200 }])
     const payload = makePayload()

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -181,6 +181,12 @@ delivery.
 - Otherwise the backend generates a new UUID v4 and attaches it to both the
   request context (`res.locals.requestId`) and the response header.
 
+When the backend delivers webhook events to a merchant endpoint, the same
+`X-Request-Id` is forwarded as a header on the outbound POST (every retry
+included), so merchants can correlate a delivery with the original request in
+their own logs. It is also recorded as `request_id` on the webhook delivery
+record.
+
 ### Filtering logs by correlation ID
 
 Capture the ID from a response and grep backend logs:


### PR DESCRIPTION

Closes #418
Closes #419
Closes #420
Closes #421

## Summary

`middleware/correlationId.ts` (#224) attaches a correlation ID to every inbound request, but `services/webhook-delivery.ts` sent outbound webhook POSTs to merchant endpoints **without** forwarding it. That made it impossible to trace a single event across both the COMEBACKHERE backend and the receiving merchant's logs — a merchant's webhook receiver would silently miss an event with no way to correlate it back to the originating request.

This PR threads the correlation ID through webhook delivery so outbound POSTs carry the same `X-Request-Id` header as the original request.

## Changes

**`comebackhere-backend/src/services/webhook-delivery.ts`**
- `postWebhook` accepts an optional `correlationId` and sends it as an `X-Request-Id` header (the same header name the middleware uses inbound). The header is omitted entirely when no correlation ID is supplied, keeping behavior backward compatible.
- `deliverWebhook` accepts the same optional `correlationId`, forwards it on **every** retry attempt (mirroring how `idempotency_key` is preserved), and records it as `request_id` on the returned delivery record.
- Terminal-failure log lines now include `requestId=...` so failed deliveries can be traced back to the original request.

**`comebackhere-backend/src/tests/webhook-delivery.test.ts`**
- 4 new tests: `X-Request-Id` forwarded on every attempt including retries; header omitted when no correlation ID is supplied; `request_id` recorded on the delivery record; `request_id` is `null` when absent.

**`docs/troubleshooting.md`**
- Documents that outbound webhook POSTs carry the same `X-Request-Id` (all retries included) and that it is stored as `request_id` on the delivery record.

## Usage

A route handler that triggers delivery passes the ID from the middleware context:

```ts
await deliverWebhook(url, payload, undefined, undefined, undefined, res.locals.requestId)
```

## Verification

- `webhook-delivery.test.ts`: 18/18 pass (14 existing + 4 new).
- Full backend suite: 70 passed / 7 failed — identical failure set to `main` (the failures are pre-existing: duplicate declarations in `src/db/mongo.ts` break several test files at transform time; `tsc --noEmit` reports the same 29 errors before and after this change, none in touched files).
- All new parameters are optional, so no existing callers or tests are affected.

## Related

- Correlation ID middleware: #224
- Webhook delivery service: #217