### PR TITLE
feat: show treasury USDC balance before escrow release

### DIFF
--- a/comebackhere-frontend/src/components/EscrowRelease.tsx
+++ b/comebackhere-frontend/src/components/EscrowRelease.tsx
@@ -1,8 +1,12 @@
-import { useState } from "react"
+import { useCallback, useState } from "react"
 import { useInvoice } from "../hooks/useInvoice"
 import { useWallet } from "../hooks/useWallet"
+import { usePolling } from "../hooks/usePolling"
+import { fetchBalances } from "../utils/treasury"
 import { StatusBadge } from "./StatusBadge"
 import { InvoiceStatus } from "../types"
+
+const TREASURY_BALANCE_POLL_MS = 10_000
 
 export function EscrowRelease() {
   const { invoice, loading, error, loadInvoice, release } = useInvoice()
@@ -14,6 +18,8 @@ export function EscrowRelease() {
     hash?: string
     errorMsg?: string
   } | null>(null)
+  const [treasuryBalance, setTreasuryBalance] = useState<string | null>(null)
+  const [balanceError, setBalanceError] = useState<string | null>(null)
 
   const handleLoadInvoice = async () => {
     setResult(null)
@@ -35,6 +41,31 @@ export function EscrowRelease() {
 
   const isMerchantWallet = address && invoice?.merchant && address.toLowerCase() === invoice.merchant.toLowerCase()
   const canRelease = connected && invoice?.status === InvoiceStatus.Paid && isMerchantWallet
+
+  // Polled (not one-shot) so a balance that was sufficient when the invoice
+  // was first loaded doesn't go stale while the merchant reviews the release.
+  const loadTreasuryBalance = useCallback(async () => {
+    if (!invoice || invoice.status !== InvoiceStatus.Paid) return
+    try {
+      const balances = await fetchBalances(address ?? invoice.merchant)
+      setTreasuryBalance(balances[0]?.balance ?? "0")
+      setBalanceError(null)
+    } catch (err) {
+      setBalanceError(
+        err instanceof Error ? err.message : "Failed to fetch treasury balance"
+      )
+    }
+  }, [address, invoice])
+
+  usePolling(loadTreasuryBalance, {
+    interval: TREASURY_BALANCE_POLL_MS,
+    enabled: invoice?.status === InvoiceStatus.Paid,
+  })
+
+  const insufficientTreasuryFunds =
+    invoice != null &&
+    treasuryBalance !== null &&
+    Number(treasuryBalance) < Number(invoice.amount_usdc)
 
   return (
     <div className="escrow-release">
@@ -99,6 +130,18 @@ export function EscrowRelease() {
               <span className="detail-label">Status</span>
               <StatusBadge status={invoice.status} />
             </div>
+            {invoice.status === InvoiceStatus.Paid && (
+              <div className="detail-row">
+                <span className="detail-label">Treasury USDC Balance</span>
+                <span className="detail-value">
+                  {balanceError
+                    ? "Unavailable"
+                    : treasuryBalance === null
+                    ? "Loading..."
+                    : treasuryBalance}
+                </span>
+              </div>
+            )}
           </div>
 
           <div className="invoice-card__actions">
@@ -112,7 +155,34 @@ export function EscrowRelease() {
               </button>
             )}
 
-            {connected && canRelease && (
+            {connected && canRelease && insufficientTreasuryFunds && (
+              <div
+                style={{
+                  padding: "12px",
+                  background: "var(--color-warning-bg)",
+                  border: "1px solid var(--color-warning-border)",
+                  borderRadius: "var(--radius)",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                }}
+                role="alert"
+              >
+                <span style={{ flex: 1 }}>
+                  Treasury balance ({treasuryBalance} USDC) is below this invoice's amount
+                  ({invoice.amount_usdc} USDC). Releasing now would likely fail.
+                </span>
+                <button
+                  className="btn btn--primary"
+                  disabled
+                  title="Treasury does not currently hold enough USDC to settle this release"
+                >
+                  Release Escrow
+                </button>
+              </div>
+            )}
+
+            {connected && canRelease && !insufficientTreasuryFunds && (
               <button
                 className="btn btn--primary"
                 onClick={handleRelease}

--- a/comebackhere-frontend/src/tests/EscrowRelease.test.tsx
+++ b/comebackhere-frontend/src/tests/EscrowRelease.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { EscrowRelease } from "../components/EscrowRelease"
+
+const merchantAddress = "GDR7WUDWIKWVBCUBVYLOGT3TJF5FGNQU5U7TACDDA2ZIQUETGGUET5XT"
+
+const mockInvoice = {
+  id: "42",
+  merchant: merchantAddress,
+  payer: "GBDXOEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  amount_usdc: "1000",
+  gross_usdc: "1050",
+  expires_at: Math.floor(Date.now() / 1000) + 86400,
+  status: "Paid" as const,
+  paid_at: 1700000000,
+  metadata_hash: null,
+  payment_link_hash: null,
+}
+
+let mockUseInvoice: any
+let mockUseWallet: any
+const fetchBalancesMock = vi.fn()
+
+vi.mock("../hooks/useInvoice", () => ({
+  useInvoice: () => mockUseInvoice,
+}))
+
+vi.mock("../hooks/useWallet", () => ({
+  useWallet: () => mockUseWallet,
+}))
+
+vi.mock("../utils/treasury", () => ({
+  fetchBalances: (address: string) => fetchBalancesMock(address),
+}))
+
+beforeEach(() => {
+  fetchBalancesMock.mockReset()
+  fetchBalancesMock.mockResolvedValue([{ token: "USDC", balance: "5000" }])
+
+  mockUseInvoice = {
+    invoice: mockInvoice,
+    loading: false,
+    error: null,
+    loadInvoice: vi.fn(),
+    release: vi.fn(),
+  }
+  mockUseWallet = {
+    address: merchantAddress,
+    connected: true,
+    connecting: false,
+    connect: vi.fn(),
+  }
+})
+
+describe("EscrowRelease treasury balance", () => {
+  it("fetches and displays the treasury's current USDC balance for a Paid invoice", async () => {
+    render(<EscrowRelease />)
+
+    await waitFor(() => expect(fetchBalancesMock).toHaveBeenCalled())
+    expect(await screen.findByText("Treasury USDC Balance")).toBeInTheDocument()
+    expect(await screen.findByText("5000")).toBeInTheDocument()
+  })
+
+  it("does not fetch a treasury balance for a non-Paid invoice", () => {
+    mockUseInvoice.invoice = { ...mockInvoice, status: "Pending" }
+    render(<EscrowRelease />)
+
+    expect(screen.queryByText("Treasury USDC Balance")).not.toBeInTheDocument()
+    expect(fetchBalancesMock).not.toHaveBeenCalled()
+  })
+
+  it("enables release when the treasury balance covers the invoice amount", async () => {
+    fetchBalancesMock.mockResolvedValue([{ token: "USDC", balance: "1000" }])
+    render(<EscrowRelease />)
+
+    const releaseButton = await screen.findByRole("button", { name: "Release Escrow" })
+    await waitFor(() => expect(releaseButton).not.toBeDisabled())
+  })
+
+  it("disables release and shows an inline warning when the treasury balance is insufficient", async () => {
+    fetchBalancesMock.mockResolvedValue([{ token: "USDC", balance: "500" }])
+    render(<EscrowRelease />)
+
+    await waitFor(() => expect(fetchBalancesMock).toHaveBeenCalled())
+    const releaseButton = await screen.findByRole("button", { name: "Release Escrow" })
+    expect(releaseButton).toBeDisabled()
+    expect(screen.getByRole("alert")).toHaveTextContent(/below this invoice's amount/i)
+  })
+
+  it("shows an unavailable state when the balance fetch fails", async () => {
+    fetchBalancesMock.mockRejectedValue(new Error("network error"))
+    render(<EscrowRelease />)
+
+    expect(await screen.findByText("Unavailable")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Addresses the EscrowRelease gap flagged against #254: the merchant-only
authorization guard was in place, but the merchant had no visibility into
whether the treasury actually held enough USDC to settle the release before
confirming it. That meant a merchant could submit a release doomed to fail
on-chain due to insufficient treasury funds — a wasted transaction and the
kind of quiet reliability gap that erodes trust in a payments product even
when the contracts themselves are working correctly.

## Changes

- `EscrowRelease` now fetches the treasury's current USDC balance whenever a
  `Paid` invoice is loaded, reusing the existing `fetchBalances()` helper and
  `GET /api/treasury/balances` endpoint already relied on by
  `TreasuryManager` — no new backend work needed.
- The balance is displayed alongside the invoice details ("Treasury USDC
  Balance") and is polled every 10s via the existing `usePolling` hook so it
  doesn't go stale while the merchant is reviewing the release.
- When the treasury balance is below the invoice's `amount_usdc`, the
  "Release Escrow" button is disabled and an inline warning is shown instead,
  matching the existing wrong-wallet warning pattern in the same component.

## Out of scope

A related ticket (#248) asked whether RefundRequest's inline validation
blocks a refund amount greater than the invoice's paid amount. After tracing
the full stack (contract `request_refund`, backend `RefundRequest` type, and
the frontend form/hook), refunds are full-refund-only everywhere — there is
no amount input or partial-refund concept anywhere in the system, so there's
no client-side gap to guard against. Left untouched; flagging here in case
partial refunds become a real feature later.

## Test plan

- [x] `npx vitest run` — 131/131 passing, including new
      `src/tests/EscrowRelease.test.tsx` (balance fetch/display, no fetch for
      non-Paid invoices, release enabled when funds suffice, release disabled
      + warning when they don't, "Unavailable" state on fetch failure)
- [x] `npx tsc -b --noEmit` — clean on touched files (two pre-existing,
      unrelated errors elsewhere in the repo)
- [x] `npx eslint` — clean on `EscrowRelease.tsx`

this pr closes #441 
this pr closes #449 
this pr closes #442 
this pr closes #448 