### PR TITLE
Feature/compliance batch and hardening

### DIFF
--- a/COMEBACKHERE-contracts/contracts/compliance/src/lib.rs
+++ b/COMEBACKHERE-contracts/contracts/compliance/src/lib.rs
@@ -152,6 +152,10 @@ impl ComplianceContract {
                 .publish((Symbol::new(&e, "address_allowed"),), (addr.clone(), until));
         }
 
+        e.events().publish(
+            (Symbol::new(&e, "compliance_batch_processed"),),
+            (admin, addresses.len()),
+        );
         Ok(())
     }
 
@@ -359,6 +363,10 @@ mod tests {
             .filter(|ev| ev.0 == (cid.clone(), "address_allowed".into()))
             .count();
         assert_eq!(allowed_count, 3);
+
+        assert!(all_events
+            .iter()
+            .any(|ev| ev.0 == (cid.clone(), "compliance_batch_processed".into())));
     }
 
     #[test]
@@ -395,6 +403,36 @@ mod tests {
         }
 
         c.batch_allow_addresses(&admin, &addresses, &2000u64);
+
+        let all_events = e.events().all();
+        assert!(all_events
+            .iter()
+            .any(|ev| ev.0 == (cid.clone(), "compliance_batch_processed".into())));
+    }
+
+    #[test]
+    fn test_batch_allow_addresses_summary_event_emitted_once_per_batch() {
+        let (e, cid, admin, _addr) = setup(1000);
+        let c = ComplianceContractClient::new(&e, &cid);
+        let addresses = soroban_sdk::vec![
+            &e,
+            Address::generate(&e),
+            Address::generate(&e),
+            Address::generate(&e),
+            Address::generate(&e)
+        ];
+
+        c.batch_allow_addresses(&admin, &addresses, &2000u64);
+
+        let all_events = e.events().all();
+        let summary_count = all_events
+            .iter()
+            .filter(|ev| ev.0 == (cid.clone(), "compliance_batch_processed".into()))
+            .count();
+        assert_eq!(
+            summary_count, 1,
+            "exactly one compliance_batch_processed event should be emitted per batch call"
+        );
     }
 
     #[test]

--- a/COMEBACKHERE-contracts/contracts/compliance/src/lib.rs
+++ b/COMEBACKHERE-contracts/contracts/compliance/src/lib.rs
@@ -267,6 +267,42 @@ mod tests {
         assert!(c.is_allowed(&addr));
     }
 
+    // ── clear_address / expiry interaction ─────────────────────────────────────
+
+    #[test]
+    fn test_clear_address_before_expiry() {
+        let (e, cid, admin, addr) = setup(1000);
+        let c = ComplianceContractClient::new(&e, &cid);
+        c.allow_address_until(&admin, &addr, &2000u64);
+        assert!(c.is_allowed(&addr));
+
+        c.clear_address(&admin, &addr);
+        assert!(!c.is_allowed(&addr));
+    }
+
+    #[test]
+    fn test_clear_address_after_expiry() {
+        let (e, cid, admin, addr) = setup(1000);
+        let c = ComplianceContractClient::new(&e, &cid);
+        c.allow_address_until(&admin, &addr, &2000u64);
+        e.ledger().with_mut(|li| li.timestamp = 2001);
+        assert!(!c.is_allowed(&addr));
+
+        c.clear_address(&admin, &addr);
+        assert!(!c.is_allowed(&addr));
+    }
+
+    #[test]
+    fn test_clear_address_never_allowed() {
+        let (e, cid, admin, addr) = setup(1000);
+        let c = ComplianceContractClient::new(&e, &cid);
+        assert!(!c.is_allowed(&addr));
+
+        let res = c.try_clear_address(&admin, &addr);
+        assert_eq!(res, Err(Ok(ContractError::AddressNotFound)));
+        assert!(!c.is_allowed(&addr));
+    }
+
     #[test]
     fn test_permanent_allow_unaffected_by_time() {
         let (_e, c, admin, addr) = setup(9999);

--- a/COMEBACKHERE-contracts/contracts/compliance/src/lib.rs
+++ b/COMEBACKHERE-contracts/contracts/compliance/src/lib.rs
@@ -11,6 +11,7 @@ pub enum ContractError {
     AlreadyInitialized = 3,
     AddressNotFound = 4,
     PastExpiry = 5,
+    BatchTooLarge = 6,
 }
 
 #[contracttype]
@@ -54,6 +55,9 @@ fn check_not_past_expiry(e: &Env, until: u64) -> Result<(), ContractError> {
         Ok(())
     }
 }
+
+/// Maximum number of addresses accepted by a single `batch_allow_addresses` call.
+const MAX_BATCH_SIZE: u32 = 50;
 
 #[contractimpl]
 impl ComplianceContract {
@@ -119,6 +123,35 @@ impl ComplianceContract {
         );
         e.events()
             .publish((Symbol::new(&e, "address_allowed_until"),), (addr, until));
+        Ok(())
+    }
+
+    /// Allows a batch of addresses until the given timestamp in a single invocation.
+    /// Enforces the same admin-only authorization and expiry validation as
+    /// `allow_address_until`, and rejects the whole batch (no partial writes)
+    /// if `addresses.len()` exceeds `MAX_BATCH_SIZE`.
+    pub fn batch_allow_addresses(
+        e: Env,
+        admin: Address,
+        addresses: Vec<Address>,
+        until: u64,
+    ) -> Result<(), ContractError> {
+        check_not_paused(&e)?;
+        admin.require_auth();
+        check_not_past_expiry(&e, until)?;
+        if addresses.len() > MAX_BATCH_SIZE {
+            return Err(ContractError::BatchTooLarge);
+        }
+
+        for addr in addresses.iter() {
+            e.storage().instance().set(
+                &DataKey::Status(addr.clone()),
+                &AddressStatus::AllowedUntil(until),
+            );
+            e.events()
+                .publish((Symbol::new(&e, "address_allowed"),), (addr.clone(), until));
+        }
+
         Ok(())
     }
 
@@ -301,6 +334,78 @@ mod tests {
         let res = c.try_clear_address(&admin, &addr);
         assert_eq!(res, Err(Ok(ContractError::AddressNotFound)));
         assert!(!c.is_allowed(&addr));
+    }
+
+    // ── batch_allow_addresses ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_batch_allow_addresses_allows_all_and_emits_events() {
+        let (e, cid, admin, _addr) = setup(1000);
+        let c = ComplianceContractClient::new(&e, &cid);
+        let a1 = Address::generate(&e);
+        let a2 = Address::generate(&e);
+        let a3 = Address::generate(&e);
+        let addresses = soroban_sdk::vec![&e, a1.clone(), a2.clone(), a3.clone()];
+
+        c.batch_allow_addresses(&admin, &addresses, &2000u64);
+
+        assert!(c.is_allowed(&a1));
+        assert!(c.is_allowed(&a2));
+        assert!(c.is_allowed(&a3));
+
+        let all_events = e.events().all();
+        let allowed_count = all_events
+            .iter()
+            .filter(|ev| ev.0 == (cid.clone(), "address_allowed".into()))
+            .count();
+        assert_eq!(allowed_count, 3);
+    }
+
+    #[test]
+    fn test_batch_allow_addresses_rejects_past_expiry() {
+        let (e, cid, admin, _addr) = setup(2000);
+        let c = ComplianceContractClient::new(&e, &cid);
+        let a1 = Address::generate(&e);
+        let addresses = soroban_sdk::vec![&e, a1];
+
+        let res = c.try_batch_allow_addresses(&admin, &addresses, &1000u64);
+        assert_eq!(res, Err(Ok(ContractError::PastExpiry)));
+    }
+
+    #[test]
+    fn test_batch_allow_addresses_rejects_over_cap() {
+        let (e, cid, admin, _addr) = setup(1000);
+        let c = ComplianceContractClient::new(&e, &cid);
+        let mut addresses = Vec::new(&e);
+        for _ in 0..51 {
+            addresses.push_back(Address::generate(&e));
+        }
+
+        let res = c.try_batch_allow_addresses(&admin, &addresses, &2000u64);
+        assert_eq!(res, Err(Ok(ContractError::BatchTooLarge)));
+    }
+
+    #[test]
+    fn test_batch_allow_addresses_accepts_exactly_cap() {
+        let (e, cid, admin, _addr) = setup(1000);
+        let c = ComplianceContractClient::new(&e, &cid);
+        let mut addresses = Vec::new(&e);
+        for _ in 0..50 {
+            addresses.push_back(Address::generate(&e));
+        }
+
+        c.batch_allow_addresses(&admin, &addresses, &2000u64);
+    }
+
+    #[test]
+    fn test_batch_allow_addresses_blocked_when_paused() {
+        let (e, cid, admin, _addr) = setup(1000);
+        let c = ComplianceContractClient::new(&e, &cid);
+        let addresses = soroban_sdk::vec![&e, Address::generate(&e)];
+
+        c.pause(&admin);
+        let res = c.try_batch_allow_addresses(&admin, &addresses, &2000u64);
+        assert_eq!(res, Err(Ok(ContractError::ContractPaused)));
     }
 
     #[test]

--- a/COMEBACKHERE-contracts/contracts/compliance/src/lib.rs
+++ b/COMEBACKHERE-contracts/contracts/compliance/src/lib.rs
@@ -10,6 +10,7 @@ pub enum ContractError {
     ContractPaused = 2,
     AlreadyInitialized = 3,
     AddressNotFound = 4,
+    PastExpiry = 5,
 }
 
 #[contracttype]
@@ -41,6 +42,14 @@ fn is_paused(e: &Env) -> bool {
 fn check_not_paused(e: &Env) -> Result<(), ContractError> {
     if is_paused(e) {
         Err(ContractError::ContractPaused)
+    } else {
+        Ok(())
+    }
+}
+
+fn check_not_past_expiry(e: &Env, until: u64) -> Result<(), ContractError> {
+    if until <= e.ledger().timestamp() {
+        Err(ContractError::PastExpiry)
     } else {
         Ok(())
     }
@@ -103,6 +112,7 @@ impl ComplianceContract {
     ) -> Result<(), ContractError> {
         check_not_paused(&e)?;
         admin.require_auth();
+        check_not_past_expiry(&e, until)?;
         e.storage().instance().set(
             &DataKey::Status(addr.clone()),
             &AddressStatus::AllowedUntil(until),
@@ -212,18 +222,49 @@ mod tests {
 
     #[test]
     fn test_is_allowed_exactly_at_expiry_returns_false() {
+        // `until` must be in the future at creation time (issue: past-expiry
+        // rejection), so we advance the ledger to the boundary afterwards
+        // instead of creating the entry already-expired.
         let (e, cid, admin, addr) = setup(1000);
         let c = ComplianceContractClient::new(&e, &cid);
-        c.allow_address_until(&admin, &addr, &1000u64);
+        c.allow_address_until(&admin, &addr, &2000u64);
+        e.ledger().with_mut(|li| li.timestamp = 2000);
         assert!(!c.is_allowed(&addr));
     }
 
     #[test]
     fn test_is_allowed_past_expiry_returns_false() {
-        let (e, cid, admin, addr) = setup(1001);
+        let (e, cid, admin, addr) = setup(1000);
         let c = ComplianceContractClient::new(&e, &cid);
-        c.allow_address_until(&admin, &addr, &1000u64);
+        c.allow_address_until(&admin, &addr, &2000u64);
+        e.ledger().with_mut(|li| li.timestamp = 2001);
         assert!(!c.is_allowed(&addr));
+    }
+
+    // ── allow_address_until past-expiry validation ─────────────────────────────
+
+    #[test]
+    fn test_allow_address_until_rejects_past_timestamp() {
+        let (e, cid, admin, addr) = setup(2000);
+        let c = ComplianceContractClient::new(&e, &cid);
+        let res = c.try_allow_address_until(&admin, &addr, &1000u64);
+        assert_eq!(res, Err(Ok(ContractError::PastExpiry)));
+    }
+
+    #[test]
+    fn test_allow_address_until_rejects_timestamp_equal_to_now() {
+        let (e, cid, admin, addr) = setup(2000);
+        let c = ComplianceContractClient::new(&e, &cid);
+        let res = c.try_allow_address_until(&admin, &addr, &2000u64);
+        assert_eq!(res, Err(Ok(ContractError::PastExpiry)));
+    }
+
+    #[test]
+    fn test_allow_address_until_accepts_future_timestamp() {
+        let (e, cid, admin, addr) = setup(2000);
+        let c = ComplianceContractClient::new(&e, &cid);
+        c.allow_address_until(&admin, &addr, &2001u64);
+        assert!(c.is_allowed(&addr));
     }
 
     #[test]

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -60,6 +60,9 @@ Defined in `COMEBACKHERE-contracts/contracts/compliance/src/lib.rs`.
 | 2 | `ContractPaused` | A state-changing call was made while the compliance contract is paused. | Compliance check calls return early on pause; defer the user action or have the admin unpause. |
 | 3 | `AlreadyInitialized` | `initialize` was called on a contract that is already set up. | Deployment-time error. The compliance contract can only be initialised once. |
 | 4 | `AddressNotFound` | A status query (or block/unblock flow) referenced an address that has not been recorded in `Status(Address)`. | Register the address via `set_status` first, or use the `Cleared` default if no entry exists. |
+| 5 | `PastExpiry` | `allow_address_until` was called with `until <= env.ledger().timestamp()`. | Pass a `until` timestamp strictly greater than the current ledger time. An already-expired entry is rejected rather than silently created as a no-op. |
+
+> Note: the enum in `COMEBACKHERE-contracts/contracts/compliance/src/lib.rs` is named `ContractError`, matching the naming convention used by the invoice and treasury contracts in this repo. It is sometimes referred to informally as `ComplianceError` in design discussions — they are the same type.
 
 ---
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -60,7 +60,8 @@ Defined in `COMEBACKHERE-contracts/contracts/compliance/src/lib.rs`.
 | 2 | `ContractPaused` | A state-changing call was made while the compliance contract is paused. | Compliance check calls return early on pause; defer the user action or have the admin unpause. |
 | 3 | `AlreadyInitialized` | `initialize` was called on a contract that is already set up. | Deployment-time error. The compliance contract can only be initialised once. |
 | 4 | `AddressNotFound` | A status query (or block/unblock flow) referenced an address that has not been recorded in `Status(Address)`. | Register the address via `set_status` first, or use the `Cleared` default if no entry exists. |
-| 5 | `PastExpiry` | `allow_address_until` was called with `until <= env.ledger().timestamp()`. | Pass a `until` timestamp strictly greater than the current ledger time. An already-expired entry is rejected rather than silently created as a no-op. |
+| 5 | `PastExpiry` | `allow_address_until` or `batch_allow_addresses` was called with `until <= env.ledger().timestamp()`. | Pass a `until` timestamp strictly greater than the current ledger time. An already-expired entry is rejected rather than silently created as a no-op. |
+| 6 | `BatchTooLarge` | `batch_allow_addresses` was called with more than 50 addresses in a single invocation. | Split the address list into batches of 50 or fewer and submit multiple `batch_allow_addresses` calls. |
 
 > Note: the enum in `COMEBACKHERE-contracts/contracts/compliance/src/lib.rs` is named `ContractError`, matching the naming convention used by the invoice and treasury contracts in this repo. It is sometimes referred to informally as `ComplianceError` in design discussions — they are the same type.
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -65,6 +65,25 @@ Defined in `COMEBACKHERE-contracts/contracts/compliance/src/lib.rs`.
 
 > Note: the enum in `COMEBACKHERE-contracts/contracts/compliance/src/lib.rs` is named `ContractError`, matching the naming convention used by the invoice and treasury contracts in this repo. It is sometimes referred to informally as `ComplianceError` in design discussions — they are the same type.
 
+See [Compliance events](#compliance-events) below for the event shapes emitted by `batch_allow_addresses` and the other compliance entry points.
+
+---
+
+## Compliance events
+
+Defined in `COMEBACKHERE-contracts/contracts/compliance/src/lib.rs`. Every state-changing compliance call emits one or more Soroban events so an off-chain indexer can reconstruct allowlist state without re-reading contract storage.
+
+| Event topic | Emitted by | Data payload | Notes |
+| ------------- | ------------ | --------------- | ------- |
+| `address_allowed` | `allow_address` | `Address` | Permanent allow, no expiry. |
+| `address_allowed` | `batch_allow_addresses` | `(Address, u64)` — address and its `until` timestamp | One event per address processed. Same topic as `allow_address`, but the payload additionally carries the `until` value shared by the whole batch. |
+| `address_allowed_until` | `allow_address_until` | `(Address, u64)` — address and its `until` timestamp | Single-address, time-bounded allow. |
+| `address_blocked` | `block_address` | `Address` | |
+| `address_cleared` | `clear_address` | `(Address, AddressStatus)` — address and the status it held immediately before clearing | Never emitted when the address was already `Cleared` (that call fails with `AddressNotFound` instead). |
+| `compliance_batch_processed` | `batch_allow_addresses` | `(Address, u32)` — the calling admin and the number of addresses processed | Emitted once per `batch_allow_addresses` call, after all per-address `address_allowed` events for that call. Lets an indexer confirm a batch operation has fully landed (`processed_count` matches the number of `address_allowed` events it should have seen in that transaction) without treating event counting as the sole source of truth. |
+
+`batch_allow_addresses` caps `addresses` at 50 entries per call (`ContractError::BatchTooLarge` above that) and validates `until` the same way `allow_address_until` does (`ContractError::PastExpiry` if `until <= env.ledger().timestamp()`). Both checks run before any storage writes or events, so a rejected call has no partial effects.
+
 ---
 
 ## SettlementError


### PR DESCRIPTION
Closes #394 
Closes #395 
Closes #396 
Closes #397 

SUMMARY
1. fix(compliance): reject past-expiry timestamps in allow_address_until — Added ContractError::PastExpiry; allow_address_until now rejects
     until <= env.ledger().timestamp() instead of silently creating an already-expired entry. Updated two existing tests that relied on the old
     past-timestamp behavior (they now advance the ledger clock after creation instead), and added 3 new tests for the
     boundary/rejection/acceptance cases. Documented in docs/error-codes.md.
  2. test(compliance): cover clear_address interaction with allow_address_until expiry — Added 3 tests: clearing before expiry, clearing after
     expiry, and clearing a never-allowed address — each asserting is_allowed is false immediately after. No production code change.
  3. feat(compliance): add batch_allow_addresses for bulk merchant onboarding — New batch_allow_addresses(admin, addresses, until) entry point.
     Same admin-auth and past-expiry checks as allow_address_until, capped at 50 addresses (ContractError::BatchTooLarge above that, checked
     before any writes so a rejected batch has zero partial effects), emitting one address_allowed event per address. Documented the new error
     code.
  4. feat(compliance): emit batch summary event and document event shapes — Added a compliance_batch_processed event (payload: admin,
     processed_count) emitted once after each batch_allow_addresses call, so an indexer can confirm a batch fully landed without counting
     individual events. Added a full "Compliance events" section to docs/error-codes.md documenting every compliance event's topic, emitter, and
     payload shape.