### PR TITLE
Fix/treasury allowlist recovery docs legacy coverage

### DIFF
--- a/COMEBACKHERE-contracts/contracts/treasury/src/benchmark.rs
+++ b/COMEBACKHERE-contracts/contracts/treasury/src/benchmark.rs
@@ -73,3 +73,45 @@ fn bench_propose_settlement_deterministic() {
         "propose_settlement CPU cost should be deterministic"
     );
 }
+
+/// Regression benchmark for the reordering in #31: the token allowlist check
+/// now runs before the pause and signer-auth checks in `propose_settlement`,
+/// so a disallowed token should be rejected for meaningfully less than the
+/// cost of a full accepted validation pass, rather than paying for
+/// pause/auth work first and only then failing on the allowlist.
+#[test]
+fn bench_propose_settlement_rejected_token_cheaper_than_accepted() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(TreasuryContract, ());
+    let client = TreasuryContractClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    let signer = Address::generate(&e);
+    let allowed_token = Address::generate(&e);
+    let disallowed_token = Address::generate(&e);
+    let merchant = Address::generate(&e);
+
+    client.initialize(&vec![&e, (signer.clone(), 1u64)], &1, &admin);
+    client.add_token_to_allowlist(&admin, &allowed_token);
+
+    e.budget().reset_unlimited();
+    let cpu_accept_before = e.budget().get_cpu_instructions_used();
+    client.propose_settlement(&signer, &allowed_token, &5_000_000u64, &merchant);
+    let cpu_accept_after = e.budget().get_cpu_instructions_used();
+    let cpu_accept = cpu_accept_after - cpu_accept_before;
+
+    e.budget().reset_unlimited();
+    let cpu_reject_before = e.budget().get_cpu_instructions_used();
+    let result =
+        client.try_propose_settlement(&signer, &disallowed_token, &5_000_000u64, &merchant);
+    let cpu_reject_after = e.budget().get_cpu_instructions_used();
+    let cpu_reject = cpu_reject_after - cpu_reject_before;
+
+    assert_eq!(result, Err(Ok(TreasuryError::TokenNotAllowed)));
+    assert!(
+        cpu_reject < cpu_accept,
+        "rejecting a disallowed token ({cpu_reject} cpu) should cost less than a full \
+         accepted proposal ({cpu_accept} cpu) now that the allowlist check runs first"
+    );
+}

--- a/COMEBACKHERE-contracts/contracts/treasury/src/lib.rs
+++ b/COMEBACKHERE-contracts/contracts/treasury/src/lib.rs
@@ -182,8 +182,10 @@ impl TreasuryContract {
     /// * `Ok(u64)` - The auto-incremented settlement ID for the created proposal.
     ///
     /// # Errors
-    /// * Returns [`TreasuryError::ContractPaused`] if contract operations are paused.
     /// * Returns [`TreasuryError::TokenNotAllowed`] if token allowlist is non-empty and `token` is not allowed.
+    ///   Checked first, before the pause and signer-auth checks, so a disallowed token is
+    ///   rejected without paying for the rest of a full validation pass.
+    /// * Returns [`TreasuryError::ContractPaused`] if contract operations are paused.
     pub fn propose_settlement(
         e: Env,
         signer: Address,
@@ -191,9 +193,6 @@ impl TreasuryContract {
         amount: u64,
         merchant: Address,
     ) -> Result<u64, TreasuryError> {
-        check_not_paused(&e)?;
-        signer.require_auth();
-
         let allowlist: Vec<Address> = e
             .storage()
             .instance()
@@ -202,6 +201,9 @@ impl TreasuryContract {
         if !allowlist.is_empty() && !allowlist.contains(&token) {
             return Err(TreasuryError::TokenNotAllowed);
         }
+
+        check_not_paused(&e)?;
+        signer.require_auth();
 
         let settlement_id: u64 = e
             .storage()
@@ -1115,6 +1117,29 @@ mod tests {
         c.remove_token_from_allowlist(&admin, &token1);
         let s2 = c.propose_settlement(&signer, &token2, &100u64, &merchant);
         assert_eq!(s2, 2u64);
+    }
+
+    #[test]
+    fn test_token_allowlist_checked_before_paused() {
+        let (e, id) = setup();
+        let c = client(&e, &id);
+        let admin = soroban_sdk::Address::generate(&e);
+        let signer = soroban_sdk::Address::generate(&e);
+        let token1 = soroban_sdk::Address::generate(&e);
+        let token2 = soroban_sdk::Address::generate(&e);
+        let merchant = soroban_sdk::Address::generate(&e);
+        c.initialize(&soroban_sdk::vec![&e, (signer.clone(), 1u64)], &1, &admin);
+        c.add_token_to_allowlist(&admin, &token1);
+        c.pause(&admin);
+
+        // With the contract paused AND the token disallowed, TokenNotAllowed
+        // must win: the allowlist check runs before the pause check.
+        let err = c.try_propose_settlement(&signer, &token2, &100u64, &merchant);
+        assert_eq!(err, Err(Ok(TreasuryError::TokenNotAllowed)));
+
+        // An allowed token still correctly surfaces ContractPaused.
+        let err = c.try_propose_settlement(&signer, &token1, &100u64, &merchant);
+        assert_eq!(err, Err(Ok(TreasuryError::ContractPaused)));
     }
 
     #[test]

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,17 @@
+# `contracts/`
+
+This is the **legacy, mirrored** Rust contracts tree. It is a valid PR
+target — it does not have its own CI workflow, and it is still referenced
+from documentation such as [`docs/error-codes.md`](../docs/error-codes.md)
+— but it is not the canonical source of truth.
+
+**[`COMEBACKHERE-contracts/`](../COMEBACKHERE-contracts/) is canonical for
+CI.** New contract work should target that tree: it is the one built and
+tested by `make test` and `.github/workflows/ci-contracts.yml` (and the
+other `ci-*.yml` workflows), and it is the source ABI snapshots in
+[`abis/`](../abis/) are generated from.
+
+See [`CONTRIBUTING.md`](../CONTRIBUTING.md#which-stack-do-i-work-on) for the
+full rule on which tree to target, and
+[`ARCHITECTURE.md`](../ARCHITECTURE.md) for why both trees exist and how
+they're kept in sync.

--- a/contracts/settlement/src/integration_settlement_multisig.rs
+++ b/contracts/settlement/src/integration_settlement_multisig.rs
@@ -1,0 +1,186 @@
+#![cfg(test)]
+
+//! Multi-sig propose/approve integration coverage for the legacy settlement
+//! contract, mirroring
+//! `COMEBACKHERE-contracts/contracts/treasury/src/integration_settlement_multisig.rs`
+//! in the canonical tree (see #31 / CONTRIBUTING.md on keeping the two trees
+//! in sync).
+//!
+//! Unlike the canonical treasury contract, this legacy contract has no
+//! separate `execute_settlement` entry point: `approve_settlement` returns
+//! the accumulated `approval_weight` and `threshold` directly, and a caller
+//! reaching quorum (`approval_weight >= threshold`) *is* the execute signal
+//! this simpler contract exposes. These tests treat "quorum reached" as the
+//! execute step the canonical tests exercise explicitly via
+//! `execute_settlement`.
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup_env() -> (Env, Address) {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, SettlementContract);
+    (e, contract_id)
+}
+
+fn make_client<'a>(e: &'a Env, id: &Address) -> SettlementContractClient<'a> {
+    SettlementContractClient::new(e, id)
+}
+
+#[test]
+fn test_multisig_propose_collect_2_of_3_reaches_quorum() {
+    let (e, id) = setup_env();
+    let c = make_client(&e, &id);
+
+    let signer_a = Address::generate(&e);
+    let signer_b = Address::generate(&e);
+    let signer_c = Address::generate(&e);
+    let merchant = Address::generate(&e);
+
+    c.initialize(
+        &soroban_sdk::vec![
+            &e,
+            (signer_a.clone(), 1u64),
+            (signer_b.clone(), 1u64),
+            (signer_c.clone(), 1u64),
+        ],
+        &2u64,
+    );
+
+    let sid = c.propose(&signer_a, &merchant, &5_000_000u64);
+
+    let r1 = c.approve_settlement(&signer_a, &sid);
+    assert_eq!(r1.approval_weight, 1);
+    assert!(
+        r1.approval_weight < r1.threshold,
+        "quorum should not be reached after 1-of-2 approvals"
+    );
+
+    let r2 = c.approve_settlement(&signer_b, &sid);
+    assert_eq!(r2.approval_weight, 2);
+    assert!(
+        r2.approval_weight >= r2.threshold,
+        "quorum should be reached after 2-of-2 approvals"
+    );
+}
+
+#[test]
+fn test_single_signer_insufficient_for_threshold_2() {
+    let (e, id) = setup_env();
+    let c = make_client(&e, &id);
+
+    let signer_a = Address::generate(&e);
+    let signer_b = Address::generate(&e);
+    let signer_c = Address::generate(&e);
+    let merchant = Address::generate(&e);
+
+    c.initialize(
+        &soroban_sdk::vec![
+            &e,
+            (signer_a.clone(), 1u64),
+            (signer_b.clone(), 1u64),
+            (signer_c.clone(), 1u64),
+        ],
+        &2u64,
+    );
+
+    let sid = c.propose(&signer_a, &merchant, &1_000_000u64);
+    let res = c.approve_settlement(&signer_a, &sid);
+
+    assert!(
+        res.approval_weight < res.threshold,
+        "a single signer must not be able to reach a threshold of 2 alone"
+    );
+}
+
+#[test]
+fn test_weighted_signers_reach_threshold() {
+    let (e, id) = setup_env();
+    let c = make_client(&e, &id);
+
+    let signer_a = Address::generate(&e);
+    let signer_b = Address::generate(&e);
+    let signer_c = Address::generate(&e);
+    let merchant = Address::generate(&e);
+
+    c.initialize(
+        &soroban_sdk::vec![
+            &e,
+            (signer_a.clone(), 2u64),
+            (signer_b.clone(), 1u64),
+            (signer_c.clone(), 1u64),
+        ],
+        &2u64,
+    );
+
+    let sid = c.propose(&signer_a, &merchant, &3_000_000u64);
+    let res = c.approve_settlement(&signer_a, &sid);
+
+    assert_eq!(res.approval_weight, 2);
+    assert!(
+        res.approval_weight >= res.threshold,
+        "a single signer with weight=2 should meet threshold=2 alone"
+    );
+}
+
+#[test]
+fn test_multiple_settlements_independent_approvals() {
+    let (e, id) = setup_env();
+    let c = make_client(&e, &id);
+
+    let signer_a = Address::generate(&e);
+    let signer_b = Address::generate(&e);
+    let merchant = Address::generate(&e);
+
+    c.initialize(
+        &soroban_sdk::vec![&e, (signer_a.clone(), 1u64), (signer_b.clone(), 1u64)],
+        &2u64,
+    );
+
+    let s1 = c.propose(&signer_a, &merchant, &1_000_000u64);
+    let s2 = c.propose(&signer_a, &merchant, &2_000_000u64);
+
+    c.approve_settlement(&signer_a, &s1);
+    let r1 = c.approve_settlement(&signer_b, &s1);
+    assert!(
+        r1.approval_weight >= r1.threshold,
+        "s1 should reach quorum"
+    );
+
+    let r2 = c.approve_settlement(&signer_a, &s2);
+    assert!(
+        r2.approval_weight < r2.threshold,
+        "s2 should still be short of quorum with only one approval"
+    );
+}
+
+#[test]
+fn test_quorum_reached_settlement_can_still_be_cancelled() {
+    // The legacy contract has no `execute_settlement` call that flips
+    // status to `Executed`; a settlement stays `Pending` (and thus
+    // cancellable) even after quorum is reached on-chain. Execution is
+    // expected to be driven by an off-chain caller reacting to
+    // `ApproveResult`.
+    let (e, id) = setup_env();
+    let c = make_client(&e, &id);
+
+    let signer_a = Address::generate(&e);
+    let signer_b = Address::generate(&e);
+    let merchant = Address::generate(&e);
+
+    c.initialize(
+        &soroban_sdk::vec![&e, (signer_a.clone(), 1u64), (signer_b.clone(), 1u64)],
+        &2u64,
+    );
+
+    let sid = c.propose(&signer_a, &merchant, &10_000_000u64);
+    c.approve_settlement(&signer_a, &sid);
+    let res = c.approve_settlement(&signer_b, &sid);
+    assert!(res.approval_weight >= res.threshold);
+
+    c.cancel(&signer_a, &sid);
+
+    let cancel_again = c.try_cancel(&signer_a, &sid);
+    assert_eq!(cancel_again, Err(Ok(SettlementError::NotPending)));
+}

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -201,6 +201,9 @@ impl SettlementContract {
 }
 
 #[cfg(test)]
+mod integration_settlement_multisig;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, Env};
@@ -403,6 +406,8 @@ mod tests {
         // Cancelling an already-cancelled (or executed) settlement fails with NotPending
         let res = c.try_cancel(&proposer, &sid);
         assert_eq!(res, Err(Ok(SettlementError::NotPending)));
+    }
+
     use proptest::prelude::*;
     extern crate std;
     use std::collections::HashSet;

--- a/docs/MAINNET_DEPLOYMENT.md
+++ b/docs/MAINNET_DEPLOYMENT.md
@@ -123,6 +123,78 @@ that itself meets the current threshold.
    their key must be removed via a signed `set_signer` transaction within 24
    hours. The remaining signers must meet quorum to execute this.
 
+### Signer Loss or Compromise Recovery
+
+This is the procedure for the scenario the rest of this document does not
+cover: a signer's key is lost or compromised, and the remaining signers can
+no longer reach the current `Threshold` even with every one of them
+approving.
+
+On-chain, `set_signer` and `update_threshold` (see
+`COMEBACKHERE-contracts/contracts/treasury/src/lib.rs`) are gated by
+`check_admin` — the single stored admin address — not by a live
+signer-quorum vote. The contract itself does not require any treasury
+signer's approval weight to execute either call. The multi-sig protection
+around this recovery path is therefore an off-chain ceremony control (the
+procedure below), the same way the rest of this document's governance
+model is enforced by process rather than by the contract.
+
+#### Recovery procedure
+
+1. **Freeze the treasury.** Call `pause(admin)` immediately to block new
+   `propose_settlement` / `approve_settlement` / `execute_settlement` calls
+   while recovery is in progress.
+2. **Convene an emergency ceremony.** Use the same [Signer
+   Roles](#signer-roles) as a deployment ceremony — Lead Deployer, remaining
+   Treasury Signers, and a Ceremony Witness at minimum — and record
+   identities and the reason for recovery in the ceremony log, per
+   [Ceremony](#ceremony).
+3. **Lower the threshold first if needed.** Compute the total weight of the
+   signers that remain trusted (excluding the lost/compromised signer). If
+   that total is below the current threshold (`get_threshold`), call
+   `update_threshold(admin, new_threshold)` to bring the threshold to at or
+   below the remaining trusted weight **before** revoking the compromised
+   signer. Doing this out of order — revoking the signer first — can leave
+   the treasury unable to reach quorum for any settlement, including the one
+   that would restore a working signer set.
+4. **Revoke the lost/compromised signer.** Call
+   `set_signer(admin, compromised_signer, 0)`. A weight of `0` removes that
+   signer's ability to approve settlements; there is no separate "remove"
+   call.
+5. **Onboard a replacement signer, if any.** Call
+   `set_signer(admin, new_signer, weight)` for the replacement key,
+   generated and custodied per [Key Custody
+   Requirements](#key-custody-requirements) (hardware wallet, distinct
+   geography, no shared custody).
+6. **Restore the threshold.** Once the replacement signer is onboarded and
+   the trusted total weight supports it, call `update_threshold` again to
+   return to (or set) the desired threshold.
+7. **Unpause.** Call `unpause(admin)` once the signer set and threshold are
+   consistent.
+8. **Record the recovery** in the deployment/ceremony log: old and new
+   signer addresses, old and new threshold values, and the transaction hash
+   for every `pause` / `update_threshold` / `set_signer` / `unpause` call.
+
+#### Minimum remaining signers needed
+
+Steps 1–7 need only the admin key's signature on-chain — `set_signer` and
+`update_threshold` do not check treasury-signer approval weight. What
+actually requires signer participation is this project's governance policy:
+under the default configuration (**3-of-5 by weight**, minimum quorum 3), an
+emergency ceremony still needs the same ceremony quorum as a normal
+deployment — **3 signers** (Treasury Signer role, 2+, plus Lead
+Deployer/Witness) — to independently verify and attest to the recovery
+before the admin key is used.
+
+A **single** lost or compromised signer (5 → 4 remaining) can always be
+recovered under the default model, since 4 remaining signers still clear the
+3-signer ceremony quorum. If **two or more** signers are lost or compromised
+at once, fewer than 3 trusted signers remain, the ceremony quorum itself
+cannot be met, and recovery is gated solely by the admin key — a residual
+single point of failure. Treat that case as a severity-1 incident (see
+[Abort Conditions](#abort-conditions)) requiring out-of-band verification of
+every remaining signer's identity before the admin proceeds.
+
 ---
 
 ## Mainnet Signing Ceremony Checklist


### PR DESCRIPTION
Closes #406 
Closes #407 
Closes #408 
Closes #409 

SUMMARY
  1. Treasury allowlist check order (COMEBACKHERE-contracts/contracts/treasury/src/lib.rs, benchmark.rs)
  Moved the token allowlist check in propose_settlement to run before check_not_paused and signer.require_auth(), so a disallowed token is now
  rejected before the contract pays for pause/auth work. Added a correctness test proving TokenNotAllowed now wins over ContractPaused when both
  conditions hold, and a benchmark asserting the rejected-token path costs less CPU than a full accepted proposal.

  2. Signer recovery documentation (docs/MAINNET_DEPLOYMENT.md)
  Added a "Signer Loss or Compromise Recovery" section documenting the set_signer/update_threshold procedure. Notably, I found both are gated only
  by the admin key on-chain (check_admin), not a live signer-quorum vote — so I documented the correct call ordering (lower threshold before
  revoking a signer, to avoid a self-inflicted deadlock) and spelled out that under the default 3-of-5 model, a single signer loss is always
  recoverable via ceremony quorum, but losing 2+ signers at once drops below ceremony quorum and leaves recovery gated solely by the admin key —
  flagged as a residual single point of failure.

  3. Legacy settlement integration tests (contracts/settlement/src/integration_settlement_multisig.rs)
  Added propose/approve multisig coverage mirroring the canonical treasury's test suite (2-of-3 quorum, insufficient single signer, weighted
  signers, independent settlements). Note: this legacy contract has no execute_settlement call — "quorum reached" via ApproveResult is treated as
  the execute signal, documented inline. Also had to fix a pre-existing bug: a missing closing brace in lib.rs's test module had the entire
  proptest quorum test nested inside another test function, which meant the crate didn't compile at all.

  4. Legacy tree README (contracts/README.md)
  New file pointing contributors landing in contracts/ to COMEBACKHERE-contracts/ as canonical for CI, linking to CONTRIBUTING.md and
  ARCHITECTURE.md.