### PR TITLE
fix: warn when grace window is set to zero seconds

### DIFF
--- a/frontend/src/components/GraceWindowSettings/GraceWindowSettings.css
+++ b/frontend/src/components/GraceWindowSettings/GraceWindowSettings.css
@@ -38,6 +38,18 @@
   margin-bottom: 0;
 }
 
+.grace-window-form__zero-warning {
+  margin-top: 0.25rem;
+  margin-bottom: 0;
+  color: var(--color-warning, #92400e);
+  background: var(--color-warning-soft-bg, #fef3c7);
+  border: 1px solid var(--color-warning-border, #fcd34d);
+  border-radius: var(--radius, 6px);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
 .form-input--error {
   border-color: var(--color-danger);
 }

--- a/frontend/src/components/GraceWindowSettings/GraceWindowSettings.test.tsx
+++ b/frontend/src/components/GraceWindowSettings/GraceWindowSettings.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+import GraceWindowSettings from './GraceWindowSettings'
+
+// Mock fetch so the component doesn't hang trying to hit /api/invoice/grace-window
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ grace_window_seconds: 86400 }),
+      headers: { get: () => null },
+    }),
+  )
+})
+
+describe('GraceWindowSettings zero-value warning', () => {
+  it('shows a non-blocking warning when the grace window is set to zero', async () => {
+    render(<GraceWindowSettings />)
+
+    // Wait for the initial fetch to complete so the input is enabled
+    await screen.findByLabelText('New duration')
+
+    const input = screen.getByLabelText('New duration')
+    fireEvent.change(input, { target: { value: '0' } })
+
+    expect(
+      await screen.findByRole('alert'),
+    ).toHaveTextContent(/zero/i)
+  })
+
+  it('does not show the zero warning for a positive value', async () => {
+    render(<GraceWindowSettings />)
+
+    await screen.findByLabelText('New duration')
+
+    const input = screen.getByLabelText('New duration')
+    fireEvent.change(input, { target: { value: '24' } })
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('keeps the Save button enabled when value is zero (non-blocking warning)', async () => {
+    render(<GraceWindowSettings />)
+
+    await screen.findByLabelText('New duration')
+
+    const input = screen.getByLabelText('New duration')
+    fireEvent.change(input, { target: { value: '0' } })
+
+    const saveBtn = screen.getByRole('button', { name: /save grace window/i })
+    expect(saveBtn).not.toBeDisabled()
+  })
+
+  it('shows a blocking error for a non-integer value instead of the zero warning', async () => {
+    render(<GraceWindowSettings />)
+
+    await screen.findByLabelText('New duration')
+
+    const input = screen.getByLabelText('New duration')
+    fireEvent.change(input, { target: { value: '1.5' } })
+
+    // Should show an error, not the zero warning
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByText(/valid non-negative integer/i)).toBeInTheDocument()
+
+    const saveBtn = screen.getByRole('button', { name: /save grace window/i })
+    expect(saveBtn).toBeDisabled()
+  })
+})

--- a/frontend/src/components/GraceWindowSettings/GraceWindowSettings.tsx
+++ b/frontend/src/components/GraceWindowSettings/GraceWindowSettings.tsx
@@ -21,7 +21,7 @@ function formatDuration(seconds: number): string {
 
 function parseDurationInput(value: string, unit: "seconds" | "minutes" | "hours" | "days"): number | null {
   const n = Number(value)
-  if (!value || Number.isNaN(n) || n <= 0 || !Number.isInteger(n)) return null
+  if (!value || Number.isNaN(n) || n < 0 || !Number.isInteger(n)) return null
 
   switch (unit) {
     case "seconds":
@@ -103,17 +103,23 @@ export default function GraceWindowSettings() {
     if (!inputValue) {
       return null // No error if field is empty (just disabled save)
     }
-    if (!parsedSeconds) {
-      return "Enter a valid positive duration"
+    if (parsedSeconds === null) {
+      return "Enter a valid non-negative integer duration"
     }
     return null
   }
 
   const validationError = getValidationError()
 
+  /** Non-blocking warning shown when the value is zero. */
+  const zeroWarning: string | null =
+    parsedSeconds === 0
+      ? "Setting the grace window to zero disables the waiting period entirely. Escrow can be released immediately after a refund request — make sure this is intentional."
+      : null
+
   const handleSave = async () => {
-    if (!parsedSeconds) {
-      setError("Enter a valid positive duration")
+    if (parsedSeconds === null) {
+      setError("Enter a valid non-negative integer duration")
       return
     }
 
@@ -147,7 +153,7 @@ export default function GraceWindowSettings() {
 
   const confirmMessage =
     parsedSeconds != null
-      ? `This will change the invoice grace window to ${formatDuration(parsedSeconds)} (${parsedSeconds} seconds) for all future escrow releases. Continue?`
+      ? `This will change the invoice grace window to ${parsedSeconds === 0 ? "zero seconds (no grace period)" : `${formatDuration(parsedSeconds)} (${parsedSeconds} seconds)`} for all future escrow releases. Continue?`
       : ""
 
   return (
@@ -183,7 +189,10 @@ export default function GraceWindowSettings() {
               }}
               disabled={loading || saving}
               aria-invalid={!!validationError}
-              aria-describedby={validationError ? "grace-validation-error" : undefined}
+              aria-describedby={
+                validationError ? "grace-validation-error" :
+                zeroWarning ? "grace-zero-warning" : undefined
+              }
             />
             <select
               className="form-input grace-window-form__unit"
@@ -201,6 +210,16 @@ export default function GraceWindowSettings() {
           {validationError && (
             <p id="grace-validation-error" className="form-error grace-window-form__inline-error">
               {validationError}
+            </p>
+          )}
+          {zeroWarning && !validationError && (
+            <p
+              id="grace-zero-warning"
+              className="grace-window-form__zero-warning"
+              role="alert"
+              aria-live="polite"
+            >
+              ⚠ {zeroWarning}
             </p>
           )}
         </div>


### PR DESCRIPTION
Closes #458 
- Allow 0 as a valid parseDurationInput value (changed n <= 0 → n < 0)
- Add non-blocking zeroWarning computed value; shown as an amber alert beneath the input when the entered duration equals zero
- Save button remains enabled — the warning is informational, not blocking
- Update confirmMessage to describe a zero-second grace window clearly
- Add GraceWindowSettings.test.tsx: 4 tests covering warning visibility, positive-value no-warning path, button-enabled-at-zero, and non-integer blocking error path

# Pull Request

## Summary

- Describe the purpose of this PR in one or two sentences.

## Checklist

- [ ] Closes #__
- [ ] Tests added or updated
- [ ] ABI snapshot updated if contract sources changed (`abis/` and `COMEBACKHERE-contracts/`)
- [ ] Screenshots attached if UI changed
- [ ] Documentation updated if needed

## Notes

- For contract changes, verify ABI snapshot hygiene with `make check-abi-snapshots`.
- For UI changes, include screenshots or screen recordings to help reviewers.
