### PR TITLE
feat: add call-to-action buttons to empty states

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import DisputeVotingPanel from "./components/DisputeVoting/DisputeVotingPanel";
 import SignerManagement from "./components/SignerManagement/SignerManagement";
 import ABIExplorer from "./components/ABIExplorer";
 import InvoiceSearchFilter from "./components/InvoiceSearchFilter";
+import { EmptyState, EmptyStateIcon } from "./components/EmptyState/EmptyState";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import OnboardingWizard from "./components/OnboardingWizard/OnboardingWizard";
 import GraceWindowSettings from "./components/GraceWindowSettings/GraceWindowSettings";
@@ -20,6 +21,23 @@ import { Invoice } from "./types";
 const MOCK_INVOICES: Invoice[] = [];
 
 function InvoicesPage() {
+  const navigate = useNavigate();
+  if (MOCK_INVOICES.length === 0) {
+    return (
+      <section>
+        <h3 style={{ marginBottom: 16 }}>Invoices</h3>
+        <EmptyState
+          icon={<EmptyStateIcon />}
+          title="No Invoices Yet"
+          description="No invoices have been created. Propose your first settlement to get started."
+          action={{
+            label: "Propose a Settlement",
+            onClick: () => navigate("/settlements"),
+          }}
+        />
+      </section>
+    );
+  }
   return (
     <section>
       <h3 style={{ marginBottom: 16 }}>Invoices</h3>
@@ -49,9 +67,10 @@ function SettlementDetailPage() {
 }
 
 function DisputesPage() {
+  const navigate = useNavigate();
   return (
     <ErrorBoundary fallbackTitle="Failed to load disputes">
-      <DisputeVotingPanel />
+      <DisputeVotingPanel onNavigateToSettlements={() => navigate("/settlements")} />
     </ErrorBoundary>
   );
 }
@@ -65,9 +84,10 @@ function SignersPage() {
 }
 
 function OnHoldPage() {
+  const navigate = useNavigate();
   return (
     <ErrorBoundary fallbackTitle="Failed to load on-hold settlements">
-      <OnHoldSettlements />
+      <OnHoldSettlements onNavigateToSettlements={() => navigate("/settlements")} />
     </ErrorBoundary>
   );
 }

--- a/frontend/src/components/DisputeVoting/DisputeVotingPanel.tsx
+++ b/frontend/src/components/DisputeVoting/DisputeVotingPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Dispute, DisputeOutcome } from '../../types/dispute'
 import { useDisputes } from '../../hooks/useDisputes'
+import { EmptyState, EmptyStateIcon } from '../EmptyState/EmptyState'
 import './DisputeVotingPanel.css'
 
 const CURRENT_SIGNER = import.meta.env.VITE_SIGNER_1 ?? ''
@@ -100,7 +101,7 @@ function formatTime(date: Date): string {
   return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }
 
-export default function DisputeVotingPanel() {
+export default function DisputeVotingPanel({ onNavigateToSettlements }: { onNavigateToSettlements?: () => void } = {}) {
   const { disputes, loading, error, voteDispute, lastUpdated, weightChanged } = useDisputes()
 
   if (loading && disputes.length === 0) return <div className="dispute-panel"><p>Loading disputes...</p></div>
@@ -129,7 +130,17 @@ export default function DisputeVotingPanel() {
         </div>
       </div>
 
-      {open.length === 0 && resolved.length === 0 && <p>No disputes found.</p>}
+      {open.length === 0 && resolved.length === 0 && (
+        <EmptyState
+          icon={<EmptyStateIcon />}
+          title="No Active Disputes"
+          description="There are no open or resolved disputes. All settlements are running normally."
+          action={onNavigateToSettlements ? {
+            label: 'View Settlements',
+            onClick: onNavigateToSettlements,
+          } : undefined}
+        />
+      )}
       {open.length > 0 && (
         <section>
           <h3 className="dispute-panel__section-title">Open Disputes</h3>

--- a/frontend/src/components/EmptyState/EmptyState.css
+++ b/frontend/src/components/EmptyState/EmptyState.css
@@ -45,6 +45,7 @@
 }
 
 .empty-state__action {
+  display: inline-block;
   margin-top: 8px;
   padding: 8px 16px;
   border: 1px solid var(--color-primary, #3b82f6);
@@ -54,6 +55,7 @@
   font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
+  text-decoration: none;
   transition: opacity 0.2s, transform 0.2s;
 }
 

--- a/frontend/src/components/EmptyState/EmptyState.test.tsx
+++ b/frontend/src/components/EmptyState/EmptyState.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { EmptyState, EmptyStateIcon } from './EmptyState'
+
+describe('EmptyState', () => {
+  it('renders title and description', () => {
+    render(
+      <EmptyState
+        title="Nothing here"
+        description="No items to display"
+      />
+    )
+    expect(screen.getByText('Nothing here')).toBeInTheDocument()
+    expect(screen.getByText('No items to display')).toBeInTheDocument()
+  })
+
+  it('renders the icon when provided', () => {
+    render(
+      <EmptyState
+        icon={<EmptyStateIcon />}
+        title="Empty"
+      />
+    )
+    expect(document.querySelector('.empty-state__icon')).toBeInTheDocument()
+  })
+
+  it('renders an action button and calls onClick when clicked', () => {
+    const handleClick = vi.fn()
+    render(
+      <EmptyState
+        title="No Settlements"
+        action={{ label: 'Propose a Settlement', onClick: handleClick }}
+      />
+    )
+
+    const btn = screen.getByRole('button', { name: 'Propose a Settlement' })
+    expect(btn).toBeInTheDocument()
+
+    fireEvent.click(btn)
+    expect(handleClick).toHaveBeenCalledOnce()
+  })
+
+  it('renders an anchor link when href is supplied', () => {
+    render(
+      <EmptyState
+        title="No Settlements"
+        action={{ label: 'Go to Settlements', href: '/settlements' }}
+      />
+    )
+
+    const link = screen.getByRole('link', { name: 'Go to Settlements' })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/settlements')
+  })
+
+  it('does not render a CTA when action is omitted', () => {
+    render(<EmptyState title="Nothing" />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/EmptyState/EmptyState.tsx
+++ b/frontend/src/components/EmptyState/EmptyState.tsx
@@ -1,5 +1,13 @@
 import './EmptyState.css'
 
+interface EmptyStateAction {
+  label: string
+  /** Called when the action button is clicked (mutually exclusive with href). */
+  onClick?: () => void
+  /** Navigate to this path instead of using an onClick handler. */
+  href?: string
+}
+
 interface EmptyStateProps {
   /**
    * Title shown in the empty state
@@ -14,12 +22,10 @@ interface EmptyStateProps {
    */
   icon?: React.ReactNode
   /**
-   * Optional action button configuration
+   * Optional action button/link configuration.
+   * Supply `onClick` for a callback-driven CTA or `href` for a navigation link.
    */
-  action?: {
-    label: string
-    onClick: () => void
-  }
+  action?: EmptyStateAction
 }
 
 export function EmptyState({
@@ -34,13 +40,24 @@ export function EmptyState({
       <h3 className="empty-state__title">{title}</h3>
       {description && <p className="empty-state__description">{description}</p>}
       {action && (
-        <button
-          className="empty-state__action"
-          onClick={action.onClick}
-          aria-label={action.label}
-        >
-          {action.label}
-        </button>
+        action.href ? (
+          <a
+            className="empty-state__action"
+            href={action.href}
+            aria-label={action.label}
+          >
+            {action.label}
+          </a>
+        ) : (
+          <button
+            className="empty-state__action"
+            onClick={action.onClick}
+            type="button"
+            aria-label={action.label}
+          >
+            {action.label}
+          </button>
+        )
       )}
     </div>
   )

--- a/frontend/src/components/OnHoldSettlements/OnHoldSettlements.tsx
+++ b/frontend/src/components/OnHoldSettlements/OnHoldSettlements.tsx
@@ -2,6 +2,11 @@ import { useState, useEffect, useCallback } from 'react'
 import { Settlement } from '../../types'
 import { EmptyState, EmptyStateIcon } from '../EmptyState/EmptyState'
 
+interface OnHoldSettlementsProps {
+  /** Optional callback invoked when the user clicks the empty-state CTA */
+  onNavigateToSettlements?: () => void
+}
+
 const API_BASE = '/api'
 
 type HoldReason = 'ComplianceReview' | 'FraudCheck' | 'KycPending' | 'AdminHold'
@@ -58,7 +63,7 @@ async function performAdminAction(settlementId: number, action: AdminAction): Pr
   return res.json()
 }
 
-export default function OnHoldSettlements() {
+export default function OnHoldSettlements({ onNavigateToSettlements }: OnHoldSettlementsProps = {}) {
   const [settlements, setSettlements] = useState<Settlement[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -129,6 +134,10 @@ export default function OnHoldSettlements() {
           icon={<EmptyStateIcon />}
           title="No On-Hold Settlements"
           description="There are currently no settlements on hold. All settlements are processing normally."
+          action={onNavigateToSettlements ? {
+            label: 'Propose a Settlement',
+            onClick: onNavigateToSettlements,
+          } : undefined}
         />
       ) : (
         <>


### PR DESCRIPTION
Closes #461 

- Add optional action prop to EmptyState supporting both onClick callback and href link variants; render as <button> or <a> accordingly
- Wire per-view CTAs:
  - InvoicesPage: 'Propose a Settlement' → /settlements (shown when list is empty)
  - OnHoldSettlements: 'Propose a Settlement' → /settlements
  - DisputeVotingPanel: 'View Settlements' → /settlements
- Add EmptyState.test.tsx covering button/link CTA rendering and no-CTA case

# Pull Request

## Summary

- Describe the purpose of this PR in one or two sentences.

## Checklist


- [ ] Tests added or updated
- [ ] ABI snapshot updated if contract sources changed (`abis/` and `COMEBACKHERE-contracts/`)
- [ ] Screenshots attached if UI changed
- [ ] Documentation updated if needed

## Notes

- For contract changes, verify ABI snapshot hygiene with `make check-abi-snapshots`.
- For UI changes, include screenshots or screen recordings to help reviewers.
