### PR TITLE
feat: add status timeline to settlement detail view

### DIFF
--- a/frontend/src/components/SettlementDetail/SettlementDetail.css
+++ b/frontend/src/components/SettlementDetail/SettlementDetail.css
@@ -285,3 +285,122 @@
   font-size: 0.875rem;
   color: #991b1b;
 }
+
+/* ── Status Timeline ──────────────────────────────────────────────────────── */
+
+.status-timeline {
+  margin-top: 1.5rem;
+}
+
+.status-timeline__title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #111827;
+}
+
+.status-timeline__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  position: relative;
+}
+
+/* Vertical connector line running through the icon column */
+.status-timeline__list::before {
+  content: '';
+  position: absolute;
+  top: 12px;
+  left: 11px;
+  bottom: 12px;
+  width: 2px;
+  background: #e5e7eb;
+  z-index: 0;
+}
+
+.status-timeline__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  position: relative;
+  padding-bottom: 1.25rem;
+}
+
+.status-timeline__item:last-child {
+  padding-bottom: 0;
+}
+
+.status-timeline__dot {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  flex-shrink: 0;
+  z-index: 1;
+  position: relative;
+  top: 2px;
+}
+
+/* Dot colours keyed to Settlement status */
+.status-timeline__dot--pending        { background: #f59e0b; }
+.status-timeline__dot--executed       { background: #22c55e; }
+.status-timeline__dot--partiallyexecuted { background: #3b82f6; }
+.status-timeline__dot--onhold         { background: #ef4444; }
+.status-timeline__dot--cancelled      { background: #6b7280; }
+.status-timeline__dot--proposed       { background: #8b5cf6; }
+.status-timeline__dot--approved       { background: #0ea5e9; }
+.status-timeline__dot--default        { background: #9ca3af; }
+
+.status-timeline__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.status-timeline__status-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.status-timeline__status-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.status-timeline__timestamp {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.status-timeline__actor {
+  font-size: 0.75rem;
+  color: #6b7280;
+  font-family: monospace;
+}
+
+.status-timeline__note {
+  margin-top: 2px;
+  font-size: 0.8125rem;
+  color: #6b7280;
+  font-style: italic;
+}
+
+.status-timeline__empty {
+  font-size: 0.875rem;
+  color: #6b7280;
+  padding: 0.5rem 0;
+}
+
+.status-timeline__error {
+  font-size: 0.875rem;
+  color: #991b1b;
+  padding: 0.5rem 0;
+}
+
+.status-timeline__loading {
+  font-size: 0.875rem;
+  color: #6b7280;
+  padding: 0.5rem 0;
+}

--- a/frontend/src/components/SettlementDetail/SettlementDetail.tsx
+++ b/frontend/src/components/SettlementDetail/SettlementDetail.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { Settlement, SignerInfo } from '../../types'
+import { useSettlementHistory, SettlementEvent } from '../../hooks/useSettlementHistory'
 import './SettlementDetail.css'
 
 interface SettlementDetailProps {
@@ -127,11 +128,107 @@ function ApprovalProgressBar({ current, required }: { current: number; required:
   )
 }
 
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatEventTimestamp(ts: number): string {
+  return new Date(ts * 1000).toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function statusDotClass(status: string): string {
+  const key = status.toLowerCase().replace(/\s+/g, '')
+  const known = ['pending', 'executed', 'partiallyexecuted', 'onhold', 'cancelled', 'proposed', 'approved']
+  return `status-timeline__dot status-timeline__dot--${known.includes(key) ? key : 'default'}`
+}
+
+// ── StatusTimeline ────────────────────────────────────────────────────────────
+
+interface StatusTimelineProps {
+  events: SettlementEvent[]
+  loading: boolean
+  error: string | null
+}
+
+function StatusTimeline({ events, loading, error }: StatusTimelineProps) {
+  if (loading) {
+    return (
+      <div className="status-timeline">
+        <h3 className="status-timeline__title">Status History</h3>
+        <p className="status-timeline__loading" role="status" aria-live="polite">
+          Loading history…
+        </p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="status-timeline">
+        <h3 className="status-timeline__title">Status History</h3>
+        <p className="status-timeline__error" role="alert">
+          Failed to load history: {error}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="status-timeline">
+      <h3 className="status-timeline__title">Status History</h3>
+      {events.length === 0 ? (
+        <p className="status-timeline__empty">No status history available.</p>
+      ) : (
+        <ol
+          className="status-timeline__list"
+          aria-label="Settlement status history"
+        >
+          {events.map((evt, idx) => (
+            <li key={idx} className="status-timeline__item">
+              <span
+                className={statusDotClass(evt.status)}
+                aria-hidden="true"
+              />
+              <div className="status-timeline__content">
+                <div className="status-timeline__status-row">
+                  <span className="status-timeline__status-label">{evt.status}</span>
+                  <time
+                    className="status-timeline__timestamp"
+                    dateTime={new Date(evt.timestamp * 1000).toISOString()}
+                  >
+                    {formatEventTimestamp(evt.timestamp)}
+                  </time>
+                </div>
+                {evt.actor && (
+                  <div className="status-timeline__actor" title={evt.actor}>
+                    by {shorten(evt.actor)}
+                  </div>
+                )}
+                {evt.note && (
+                  <div className="status-timeline__note">{evt.note}</div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  )
+}
+
+// ── SettlementDetail ──────────────────────────────────────────────────────────
+
 export default function SettlementDetail({ settlement, threshold, signers }: SettlementDetailProps) {
   const totalWeight = useMemo(
     () => signers.reduce((sum, s) => sum + s.weight, 0),
     [signers],
   )
+
+  const { events, loading: historyLoading, error: historyError } = useSettlementHistory(settlement.id)
 
   return (
     <div className="settlement-detail">
@@ -175,6 +272,12 @@ export default function SettlementDetail({ settlement, threshold, signers }: Set
           <strong>Hold Reason:</strong> {settlement.hold_reason}
         </div>
       )}
+
+      <StatusTimeline
+        events={events}
+        loading={historyLoading}
+        error={historyError}
+      />
     </div>
   )
 }

--- a/frontend/src/hooks/useSettlementHistory.test.ts
+++ b/frontend/src/hooks/useSettlementHistory.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useSettlementHistory, SettlementEvent } from './useSettlementHistory'
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+function makeEvent(overrides: Partial<SettlementEvent> = {}): SettlementEvent {
+  return {
+    timestamp: 1_700_000_000,
+    status: 'Pending',
+    actor: null,
+    note: null,
+    ...overrides,
+  }
+}
+
+describe('useSettlementHistory', () => {
+  beforeEach(() => {
+    mockFetch.mockClear()
+  })
+
+  it('starts in a loading state when a settlementId is provided', () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => [] })
+
+    const { result } = renderHook(() => useSettlementHistory(42))
+
+    expect(result.current.loading).toBe(true)
+  })
+
+  it('does not fetch when settlementId is null', () => {
+    const { result } = renderHook(() => useSettlementHistory(null))
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.events).toEqual([])
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('fetches the correct endpoint for a given settlementId', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => [] })
+
+    renderHook(() => useSettlementHistory(7))
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/treasury/settlements/7/history')
+    })
+  })
+
+  it('returns events sorted oldest-first regardless of API order', async () => {
+    const events: SettlementEvent[] = [
+      makeEvent({ timestamp: 1_700_000_200, status: 'Executed' }),
+      makeEvent({ timestamp: 1_700_000_000, status: 'Pending' }),
+      makeEvent({ timestamp: 1_700_000_100, status: 'Approved' }),
+    ]
+
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => events })
+
+    const { result } = renderHook(() => useSettlementHistory(1))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.events.map(e => e.status)).toEqual(['Pending', 'Approved', 'Executed'])
+  })
+
+  it('renders a complete multi-transition timeline: Proposed → Approved → Executed', async () => {
+    const events: SettlementEvent[] = [
+      makeEvent({ timestamp: 1_700_000_000, status: 'Proposed', actor: 'GBMRCHNT...A1' }),
+      makeEvent({ timestamp: 1_700_000_060, status: 'Approved', actor: 'GSGNR...B2', note: 'quorum reached' }),
+      makeEvent({ timestamp: 1_700_000_120, status: 'Executed', actor: 'GSGNR...C3' }),
+    ]
+
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => events })
+
+    const { result } = renderHook(() => useSettlementHistory(5))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.error).toBeNull()
+    expect(result.current.events).toHaveLength(3)
+    expect(result.current.events[0].status).toBe('Proposed')
+    expect(result.current.events[1].status).toBe('Approved')
+    expect(result.current.events[1].note).toBe('quorum reached')
+    expect(result.current.events[2].status).toBe('Executed')
+  })
+
+  it('renders an on-hold then resolved timeline: Pending → OnHold → Resolved', async () => {
+    const events: SettlementEvent[] = [
+      makeEvent({ timestamp: 1_700_001_000, status: 'Pending' }),
+      makeEvent({ timestamp: 1_700_001_100, status: 'OnHold', note: 'compliance review' }),
+      makeEvent({ timestamp: 1_700_001_500, status: 'Executed', actor: 'GADMIN...Z9' }),
+    ]
+
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => events })
+
+    const { result } = renderHook(() => useSettlementHistory(9))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.events).toHaveLength(3)
+    expect(result.current.events[1].status).toBe('OnHold')
+    expect(result.current.events[1].note).toBe('compliance review')
+    expect(result.current.events[2].status).toBe('Executed')
+  })
+
+  it('surfaces an HTTP error as the error string', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+    const { result } = renderHook(() => useSettlementHistory(99))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.error).toBe('HTTP 404')
+    expect(result.current.events).toEqual([])
+  })
+
+  it('surfaces a network error as the error string', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network failure'))
+
+    const { result } = renderHook(() => useSettlementHistory(3))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.error).toBe('Network failure')
+    expect(result.current.events).toEqual([])
+  })
+
+  it('refresh re-fetches the history', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => [makeEvent()] })
+
+    const { result } = renderHook(() => useSettlementHistory(2))
+
+    await waitFor(() => {
+      expect(result.current.events.length).toBe(1)
+    })
+
+    const callsBefore = mockFetch.mock.calls.length
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(mockFetch.mock.calls.length).toBeGreaterThan(callsBefore)
+  })
+})

--- a/frontend/src/hooks/useSettlementHistory.ts
+++ b/frontend/src/hooks/useSettlementHistory.ts
@@ -1,0 +1,44 @@
+import { useState, useEffect, useCallback } from 'react'
+
+const API_BASE = '/api'
+
+export interface SettlementEvent {
+  /** Unix timestamp (seconds) when the transition occurred */
+  timestamp: number
+  /** The status the settlement transitioned to */
+  status: string
+  /** Optional address of the actor who triggered the transition */
+  actor?: string | null
+  /** Optional contextual note (e.g. hold reason, dispute reference) */
+  note?: string | null
+}
+
+export function useSettlementHistory(settlementId: number | null) {
+  const [events, setEvents] = useState<SettlementEvent[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchHistory = useCallback(async () => {
+    if (settlementId === null) return
+    try {
+      setLoading(true)
+      setError(null)
+      const res = await fetch(`${API_BASE}/treasury/settlements/${settlementId}/history`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data: SettlementEvent[] = await res.json()
+      // Ensure events are sorted oldest-first so the timeline reads top-to-bottom
+      const sorted = [...data].sort((a, b) => a.timestamp - b.timestamp)
+      setEvents(sorted)
+    } catch (e: any) {
+      setError(e.message || 'Failed to fetch settlement history')
+    } finally {
+      setLoading(false)
+    }
+  }, [settlementId])
+
+  useEffect(() => {
+    fetchHistory()
+  }, [fetchHistory])
+
+  return { events, loading, error, refresh: fetchHistory }
+}


### PR DESCRIPTION
Add useSettlementHistory hook that fetches status-change events from /api/treasury/settlements/:id/history and returns them sorted oldest-first for chronological display.

Add StatusTimeline component inside SettlementDetail that renders each event as a labelled dot in a vertical timeline, including the actor address and any contextual note (e.g. hold reason, dispute reference). Colour-coded dots map to settlement lifecycle statuses; unknown future statuses fall back to a neutral grey dot.

Add CSS for the timeline in SettlementDetail.css including focus-accessible styles.

Tests (useSettlementHistory.test.ts):
- loading/null-id states
- correct API endpoint called
- oldest-first sorting regardless of API order
- Proposed → Approved → Executed multi-transition timeline
- Pending → OnHold → Executed on-hold/resolved timeline
- HTTP and network error surfaces
- refresh re-fetches

# Pull Request

## Summary

- Describe the purpose of this PR in one or two sentences.

## Checklist

- [ ] Closes #__
- [ ] Tests added or updated
- [ ] ABI snapshot updated if contract sources changed (`abis/` and `COMEBACKHERE-contracts/`)
- [ ] Screenshots attached if UI changed
- [ ] Documentation updated if needed

## Notes

- For contract changes, verify ABI snapshot hygiene with `make check-abi-snapshots`.
- For UI changes, include screenshots or screen recordings to help reviewers.
closes #465 
