### PR TITLE
fix: resolve issues #478 #479 #480 #481 — compliance docs, ABI --check flag, validate_env modes, deploy rollback

### DIFF
--- a/.github/workflows/ci-abi-metadata.yml
+++ b/.github/workflows/ci-abi-metadata.yml
@@ -39,14 +39,5 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Regenerate ABI metadata
-        run: bash scripts/generate_abi_metadata.sh abis
-
-      - name: Fail if ABI snapshots are stale
-        run: |
-          if ! git diff --exit-code abis/; then
-            echo ""
-            echo "ERROR: ABI snapshots in abis/ are out of date."
-            echo "Run 'make update-abi-snapshots' locally and commit the updated files."
-            exit 1
-          fi
+      - name: Verify ABI snapshots are up to date
+        run: bash scripts/generate_abi_metadata.sh --check

--- a/docs/MAINNET_DEPLOYMENT.md
+++ b/docs/MAINNET_DEPLOYMENT.md
@@ -257,13 +257,63 @@ ceremony. The Ceremony Witness records each step.
 
 ### Emergency Rollback
 
-If a critical issue is discovered after deployment:
+If a critical issue is discovered after a deployment partially or fully
+succeeds, follow this procedure.
 
-1. The Lead Deployer opens an emergency deployment issue
-2. If the contracts support pause: execute `pause` via multi-sig to halt
-   operations immediately
-3. Follow the standard ceremony process for any corrective deployment
-4. Document the incident in a post-mortem within 48 hours
+#### What rollback does and does not do
+
+**Soroban contracts cannot be un-deployed.** Any contract that was submitted
+to the Stellar ledger during the failed deployment remains on-chain and is
+accessible by anyone with its contract ID. Rollback only restores the local
+`artifacts/addresses.json` address registry so that downstream services
+(backend, frontend) can be pointed back at the previous known-good deployment.
+
+#### Scripted rollback
+
+`scripts/deploy_mainnet.sh` backs up `artifacts/addresses.json` to
+`artifacts/addresses.json.bak` before overwriting it with new contract IDs.
+To restore the previous address registry:
+
+```sh
+scripts/deploy_mainnet.sh --rollback
+```
+
+The script will:
+
+1. Confirm that `artifacts/addresses.json.bak` exists (created during the
+   previous successful deployment).
+2. Save the current (potentially corrupt) `addresses.json` as a timestamped
+   forensic copy (e.g., `addresses.json.rollback-20260101T120000Z`).
+3. Restore `artifacts/addresses.json` from the backup.
+4. Print a detailed summary of contract-level implications and next steps.
+
+If no backup file exists (e.g., this was the first ever deployment), the
+script exits with an error and provides manual recovery instructions.
+
+#### Manual recovery when no backup is available
+
+If `artifacts/addresses.json.bak` does not exist, reconstruct
+`artifacts/addresses.json` from the on-chain deployment ceremony record:
+
+1. Open the deployment issue for the last known-good deployment.
+2. Locate the recorded contract IDs (invoice, treasury, compliance) and
+   transaction hashes.
+3. Manually write `artifacts/addresses.json` using the structure defined in
+   `artifacts/addresses.json.example`.
+4. Commit the restored file and open a PR referencing the incident.
+
+#### Procedure after rollback
+
+1. The Lead Deployer opens an emergency deployment issue documenting:
+   - The partial or failed deployment's contract IDs
+   - Which contracts were deployed but not initialized
+   - The rollback timestamp and the restored address set
+2. If any contract supports `pause`: execute `pause` via multi-sig to halt
+   operations on the abandoned contract immediately.
+3. Reconfigure backend production secrets to use the restored (previous)
+   contract IDs from `artifacts/addresses.json`.
+4. Follow the standard ceremony process for any corrective redeployment.
+5. Document the incident in a post-mortem within 48 hours.
 
 ---
 

--- a/docs/contract-interaction-guide.md
+++ b/docs/contract-interaction-guide.md
@@ -382,6 +382,99 @@ soroban contract invoke \
 
 ---
 
+### Check whether an address is allowed (`is_allowed`)
+
+`is_allowed` returns `true` only when an address has been explicitly allowed
+**and** its allowance has not expired.  Three distinct scenarios produce a
+`false` result, and integrators must not treat them as equivalent — the
+appropriate response differs in each case.
+
+#### Scenario 1 — Address was never allowed
+
+The address has never been passed to `allow_address`.  `is_allowed` returns
+`false` immediately.  The correct action is to route the payer through your
+KYC/onboarding flow before retrying.
+
+```sh
+# The address GNEW... has never been allowed.
+soroban contract invoke \
+  --id $COMPLIANCE_CONTRACT \
+  --source $SECRET_KEY \
+  --rpc-url $RPC_URL \
+  --network-passphrase "$NETWORK_PASSPHRASE" \
+  -- is_allowed \
+  --address GNEWADDRESSNEVERALLOWED...
+# → false
+```
+
+Expected response: `false`
+
+The backend maps this to error code `COMPLIANCE_NOT_ALLOWED`.  Return HTTP 403
+to the caller with a message indicating that the address must complete
+onboarding before transacting.
+
+#### Scenario 2 — Address was allowed but the allowance has expired
+
+`allow_address` was called with an `expires_at` timestamp that has since
+passed.  `is_allowed` returns `false` because the allowance window closed.
+The address is not blocked — it simply needs to be re-allowed (e.g., after
+a periodic compliance re-check).
+
+```sh
+# GEXPIRED... was allowed until ledger time 1700000000, which has passed.
+soroban contract invoke \
+  --id $COMPLIANCE_CONTRACT \
+  --source $SECRET_KEY \
+  --rpc-url $RPC_URL \
+  --network-passphrase "$NETWORK_PASSPHRASE" \
+  -- is_allowed \
+  --address GEXPIREDADDRESS...
+# → false  (allowance window closed)
+```
+
+Expected response: `false`
+
+The backend maps this to error code `COMPLIANCE_ALLOWANCE_EXPIRED`.  Return
+HTTP 403 with a message telling the caller that their compliance approval has
+lapsed and they must renew it.  Do **not** present this to the user as a block
+— it is a renewal prompt.
+
+#### Scenario 3 — Address is explicitly blocked
+
+`block_address` was called for this address.  `is_allowed` returns `false`
+regardless of any prior allowance.  A blocked address must not transact until
+the block is explicitly lifted by a compliance admin.
+
+```sh
+# GBLOCKED... was explicitly blocked via block_address.
+soroban contract invoke \
+  --id $COMPLIANCE_CONTRACT \
+  --source $SECRET_KEY \
+  --rpc-url $RPC_URL \
+  --network-passphrase "$NETWORK_PASSPHRASE" \
+  -- is_allowed \
+  --address GBLOCKEDADDRESS...
+# → false  (explicit block in effect)
+```
+
+Expected response: `false`
+
+The backend maps this to error code `COMPLIANCE_BLOCKED`.  Return HTTP 403
+with a message indicating that the address is blocked from transacting.  Do
+**not** expose details about why it was blocked to the end-user; log the event
+for compliance audit purposes and direct the user to your support channel.
+
+#### Summary of `is_allowed` return values
+
+| State | `is_allowed` result | Error code | Suggested HTTP status |
+| ----- | ------------------- | ---------- | --------------------- |
+| Never allowed | `false` | `COMPLIANCE_NOT_ALLOWED` | 403 |
+| Allowance expired | `false` | `COMPLIANCE_ALLOWANCE_EXPIRED` | 403 |
+| Explicitly blocked | `false` | `COMPLIANCE_BLOCKED` | 403 |
+| Allowed and within window | `true` | — | proceed |
+
+---
+
 ## Invoice grace window
 
 ### Read

--- a/scripts/deploy_mainnet.sh
+++ b/scripts/deploy_mainnet.sh
@@ -9,31 +9,111 @@
 # without submitting any transaction.  The output is formatted to be easy to paste
 # into a deployment-checklist PR or issue.
 #
+# Use --rollback to revert artifacts/addresses.json to the last known-good
+# deployment recorded in artifacts/addresses.json.bak.  This does NOT un-deploy
+# any contracts on-chain; it only restores the local address registry so that
+# downstream services can be pointed back at the previous deployment.
+#
 # Usage:
-#   scripts/deploy_mainnet.sh --dry-run   # preview only — zero network-mutating calls
-#   scripts/deploy_mainnet.sh             # refuses; live deploy requires multi-sig ceremony
+#   scripts/deploy_mainnet.sh --dry-run    # preview only — zero network-mutating calls
+#   scripts/deploy_mainnet.sh --rollback   # restore addresses.json from backup
+#   scripts/deploy_mainnet.sh              # refuses; live deploy requires multi-sig ceremony
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 DRY_RUN=0
+ROLLBACK=0
 
 for arg in "$@"; do
   case "$arg" in
-    --dry-run) DRY_RUN=1 ;;
+    --dry-run)  DRY_RUN=1 ;;
+    --rollback) ROLLBACK=1 ;;
     *)
       echo "Unknown argument: $arg" >&2
-      echo "Usage: $0 [--dry-run]" >&2
+      echo "Usage: $0 [--dry-run | --rollback]" >&2
       exit 1
       ;;
   esac
 done
 
+# ── rollback mode ─────────────────────────────────────────────────────────────
+
+if [ "$ROLLBACK" -eq 1 ]; then
+  ADDRESSES_FILE="$ROOT_DIR/artifacts/addresses.json"
+  BACKUP_FILE="$ROOT_DIR/artifacts/addresses.json.bak"
+
+  if [ ! -f "$BACKUP_FILE" ]; then
+    echo "ERROR: No rollback backup found at $BACKUP_FILE." >&2
+    echo "" >&2
+    echo "A backup is created automatically at $BACKUP_FILE each time this script" >&2
+    echo "writes a new artifacts/addresses.json.  If no backup exists, either:" >&2
+    echo "  - This is the first ever deployment (no prior state to roll back to)" >&2
+    echo "  - The backup was manually deleted" >&2
+    echo "" >&2
+    echo "To recover manually, consult the on-chain deployment ceremony record" >&2
+    echo "in the deployment issue and reconstruct artifacts/addresses.json from" >&2
+    echo "the recorded contract IDs." >&2
+    echo "" >&2
+    echo "IMPORTANT: Rolling back artifacts/addresses.json does NOT un-deploy" >&2
+    echo "contracts on Soroban. Contracts cannot be removed from the ledger once" >&2
+    echo "deployed. This rollback only restores the local address registry so" >&2
+    echo "that backend services can be pointed back at the previous deployment." >&2
+    exit 1
+  fi
+
+  TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+  echo "========================================================"
+  echo "  COMEBACKHERE MAINNET DEPLOYMENT — ROLLBACK"
+  echo "  Generated: $TIMESTAMP"
+  echo "========================================================"
+  echo ""
+  echo "Restoring artifacts/addresses.json from backup..."
+  echo ""
+
+  if [ -f "$ADDRESSES_FILE" ]; then
+    # Save the current (failed) state for forensic reference
+    cp "$ADDRESSES_FILE" "${ADDRESSES_FILE}.rollback-$(date -u +"%Y%m%dT%H%M%SZ")"
+    echo "  Saved current addresses.json as addresses.json.rollback-${TIMESTAMP} for forensic reference."
+  fi
+
+  cp "$BACKUP_FILE" "$ADDRESSES_FILE"
+  echo "  Restored: artifacts/addresses.json from artifacts/addresses.json.bak"
+  echo ""
+  echo "IMPORTANT — Contract-level implications:"
+  echo ""
+  echo "  1. Contracts already deployed on-chain CANNOT be un-deployed."
+  echo "     Any contract that was deployed during the failed deployment remains"
+  echo "     on the Stellar ledger and is accessible by anyone with its contract ID."
+  echo ""
+  echo "  2. This rollback only restores the local artifacts/addresses.json registry."
+  echo "     Downstream services (backend, frontend) pointed at the NEW contract IDs"
+  echo "     must be manually reconfigured to use the PREVIOUS contract IDs from the"
+  echo "     restored addresses.json."
+  echo ""
+  echo "  3. If any newly deployed contract was partially initialized (e.g., the"
+  echo "     compliance contract was deployed but the invoice contract was not),"
+  echo "     the partially-initialized contract should be documented in the"
+  echo "     post-incident record. It may need to be treated as an abandoned"
+  echo "     deployment."
+  echo ""
+  echo "  4. Open an emergency deployment issue to document the partial deployment,"
+  echo "     record all deployed contract IDs (including abandoned ones), and plan"
+  echo "     any corrective redeployment through the full multi-sig ceremony process."
+  echo ""
+  echo "  See docs/MAINNET_DEPLOYMENT.md — Emergency Rollback section for full guidance."
+  echo ""
+  echo "Rollback complete."
+  echo "========================================================"
+  exit 0
+fi
+
 # ── resolve env ───────────────────────────────────────────────────────────────
 
 # shellcheck disable=SC1091
-source scripts/validate_env.sh .env.mainnet mainnet deployment
+source scripts/validate_env.sh .env.mainnet mainnet deployment --env mainnet
 
 # ── dry-run mode ──────────────────────────────────────────────────────────────
 

--- a/scripts/generate_abi_metadata.sh
+++ b/scripts/generate_abi_metadata.sh
@@ -3,10 +3,30 @@
 # Contract sources are searched in two locations (CI checkout and local sibling):
 #   1. $ROOT_DIR/COMEBACKHERE-contracts  (GitHub Actions checkout path)
 #   2. $ROOT_DIR/../COMEBACKHERE-contracts  (local sibling directory)
+#
+# Usage:
+#   scripts/generate_abi_metadata.sh [OUT_DIR]
+#       Regenerate ABI metadata and write to OUT_DIR (default: abis/).
+#
+#   scripts/generate_abi_metadata.sh --check
+#       Generate ABI metadata to a temp directory and diff against committed
+#       abis/*.json without overwriting them. Exits non-zero if there are
+#       differences (like `prettier --check`). OUT_DIR is ignored when
+#       --check is specified.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+CHECK_MODE=0
 OUT_DIR="${1:-"$ROOT_DIR/abis"}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --check)
+      CHECK_MODE=1
+      ;;
+  esac
+done
 
 if [ -d "$ROOT_DIR/COMEBACKHERE-contracts" ]; then
   CONTRACTS_DIR="$ROOT_DIR/COMEBACKHERE-contracts"
@@ -22,6 +42,28 @@ fi
 
 export LC_ALL=C
 export LANG=C
+
+if [ "$CHECK_MODE" -eq 1 ]; then
+  TEMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "$TEMP_DIR"' EXIT
+
+  echo "Building COMEBACKHERE contracts (workspace test build)..."
+  (cd "$CONTRACTS_DIR" && cargo test --no-run --workspace)
+
+  mkdir -p "$TEMP_DIR"
+  python3 "$ROOT_DIR/scripts/generate_abi_metadata.py" "$TEMP_DIR"
+
+  echo "Comparing generated ABI metadata against committed abis/..."
+  if diff -ru "$ROOT_DIR/abis/" "$TEMP_DIR/"; then
+    echo "ABI snapshots are up to date."
+    exit 0
+  else
+    echo "" >&2
+    echo "ERROR: ABI snapshots in abis/ are out of sync with COMEBACKHERE-contracts/." >&2
+    echo "Run 'make update-abi-snapshots' (or 'just snapshot') locally and commit the updated files." >&2
+    exit 1
+  fi
+fi
 
 echo "Building COMEBACKHERE contracts (workspace test build)..."
 (cd "$CONTRACTS_DIR" && cargo test --no-run --workspace)

--- a/scripts/validate_env.sh
+++ b/scripts/validate_env.sh
@@ -1,8 +1,57 @@
 #!/usr/bin/env bash
+# Validate required environment variables before deployment.
+#
+# Usage:
+#   scripts/validate_env.sh [ENV_FILE] [ENV_LABEL] [--env testnet|mainnet|local]
+#
+# The --env flag selects which set of required variables to enforce:
+#   local    — minimal set for local Docker Compose development
+#   testnet  — standard set for testnet deployments
+#   mainnet  — strict set for mainnet deployments (no test keys, additional checks)
+#
+# If --env is not specified, the script validates the common baseline variables
+# (compatible with prior behaviour).
+#
+# Examples:
+#   scripts/validate_env.sh .env.testnet testnet --env testnet
+#   scripts/validate_env.sh .env.mainnet mainnet  --env mainnet
+#   scripts/validate_env.sh .env.local   local    --env local
 set -euo pipefail
 
 ENV_FILE="${1:-}"
 ENV_LABEL="${2:-deployment}"
+ENV_MODE=""
+
+# Parse --env flag from remaining arguments
+for arg in "$@"; do
+  case "$arg" in
+    --env)
+      # next iteration will capture the value
+      ;;
+  esac
+done
+
+# Robust flag parsing: scan all args for --env <mode>
+i=1
+for arg in "$@"; do
+  if [[ "$arg" == "--env" ]]; then
+    next_i=$((i + 1))
+    eval "ENV_MODE=\"\${${next_i}:-}\""
+    break
+  fi
+  i=$((i + 1))
+done
+
+# Validate the mode value if provided
+if [[ -n "$ENV_MODE" ]]; then
+  case "$ENV_MODE" in
+    local|testnet|mainnet) ;;
+    *)
+      echo "Error: --env must be one of: local, testnet, mainnet (got '$ENV_MODE')." >&2
+      exit 1
+      ;;
+  esac
+fi
 
 if [[ -n "$ENV_FILE" && -f "$ENV_FILE" ]]; then
   # shellcheck disable=SC1090
@@ -115,6 +164,8 @@ require_any_var() {
   return 1
 }
 
+# ── common baseline variables (all modes) ────────────────────────────────────
+
 if ! require_any_var "Set SOROBAN_RPC_URL (or RPC_URL) to your Soroban RPC endpoint." "SOROBAN_RPC_URL" "RPC_URL"; then
   :
 fi
@@ -135,6 +186,97 @@ fi
 if ! require_any_var "Set ADMIN_SECRET_KEY (or SECRET_KEY) to the corresponding Stellar secret key for deployment signing." "ADMIN_SECRET_KEY" "SECRET_KEY"; then
   :
 fi
+
+# ── mode-specific variable checks ────────────────────────────────────────────
+
+case "$ENV_MODE" in
+
+  local)
+    # Local development: RPC is typically the local Docker Compose node.
+    # Verify that the RPC URL points to localhost or a local address.
+    _rpc_url="${SOROBAN_RPC_URL:-${RPC_URL:-}}"
+    if [[ -n "$_rpc_url" && "$_rpc_url" != *"localhost"* && "$_rpc_url" != *"127.0.0.1"* && "$_rpc_url" != *"0.0.0.0"* ]]; then
+      echo "Warning: --env local is set but SOROBAN_RPC_URL ('$_rpc_url') does not appear to point to a local node." >&2
+      echo "Hint: For local mode, use http://localhost:8000/soroban/rpc or similar." >&2
+    fi
+    ;;
+
+  testnet)
+    # Testnet: requires STELLAR_NETWORK to be explicitly set to 'testnet'.
+    if ! require_var "STELLAR_NETWORK" "Set STELLAR_NETWORK=testnet for testnet deployments."; then
+      :
+    else
+      if [[ "${STELLAR_NETWORK}" != "testnet" ]]; then
+        echo "Error: --env testnet requires STELLAR_NETWORK=testnet (got '${STELLAR_NETWORK}')." >&2
+        invalid+=("STELLAR_NETWORK")
+      fi
+    fi
+    # Testnet also requires deployed contract IDs to be present.
+    if ! require_var "INVOICE_CONTRACT_ID" "Set INVOICE_CONTRACT_ID to the deployed testnet invoice contract address."; then
+      :
+    fi
+    if ! require_var "TREASURY_CONTRACT_ID" "Set TREASURY_CONTRACT_ID to the deployed testnet treasury contract address."; then
+      :
+    fi
+    if ! require_var "COMPLIANCE_CONTRACT_ID" "Set COMPLIANCE_CONTRACT_ID to the deployed testnet compliance contract address."; then
+      :
+    fi
+    ;;
+
+  mainnet)
+    # Mainnet: strictest checks. Secret keys must not use testnet-only values,
+    # and the network passphrase must match the Stellar mainnet passphrase.
+    MAINNET_PASSPHRASE="Public Global Stellar Network ; September 2015"
+
+    _passphrase="${SOROBAN_NETWORK_PASSPHRASE:-${NETWORK_PASSPHRASE:-}}"
+    if [[ -n "$_passphrase" && "$_passphrase" != "$MAINNET_PASSPHRASE" ]]; then
+      echo "Error: --env mainnet requires SOROBAN_NETWORK_PASSPHRASE to equal the Stellar mainnet passphrase." >&2
+      echo "  Expected: '$MAINNET_PASSPHRASE'" >&2
+      echo "  Got:      '$_passphrase'" >&2
+      invalid+=("SOROBAN_NETWORK_PASSPHRASE")
+    fi
+
+    if ! require_var "STELLAR_NETWORK" "Set STELLAR_NETWORK=mainnet for mainnet deployments."; then
+      :
+    else
+      if [[ "${STELLAR_NETWORK}" != "mainnet" ]]; then
+        echo "Error: --env mainnet requires STELLAR_NETWORK=mainnet (got '${STELLAR_NETWORK}')." >&2
+        invalid+=("STELLAR_NETWORK")
+      fi
+    fi
+
+    # Deployed contract IDs are required for mainnet.
+    if ! require_var "INVOICE_CONTRACT_ID" "Set INVOICE_CONTRACT_ID to the deployed mainnet invoice contract address."; then
+      :
+    fi
+    if ! require_var "TREASURY_CONTRACT_ID" "Set TREASURY_CONTRACT_ID to the deployed mainnet treasury contract address."; then
+      :
+    fi
+    if ! require_var "COMPLIANCE_CONTRACT_ID" "Set COMPLIANCE_CONTRACT_ID to the deployed mainnet compliance contract address."; then
+      :
+    fi
+
+    # USDC contract ID is required on mainnet.
+    if ! require_var "USDC_CONTRACT_ID" "Set USDC_CONTRACT_ID to the official USDC asset contract ID on Stellar mainnet."; then
+      :
+    fi
+
+    # Reject obviously-testnet RPC URLs on mainnet mode.
+    _rpc_url="${SOROBAN_RPC_URL:-${RPC_URL:-}}"
+    if [[ -n "$_rpc_url" && "$_rpc_url" == *"testnet"* ]]; then
+      echo "Error: --env mainnet is set but SOROBAN_RPC_URL ('$_rpc_url') contains 'testnet'. Use a mainnet RPC endpoint." >&2
+      invalid+=("SOROBAN_RPC_URL")
+    fi
+
+    # Warn if RPC points to localhost — unusual for mainnet.
+    if [[ -n "$_rpc_url" && ( "$_rpc_url" == *"localhost"* || "$_rpc_url" == *"127.0.0.1"* ) ]]; then
+      echo "Warning: --env mainnet is set but SOROBAN_RPC_URL ('$_rpc_url') points to localhost. Confirm this is intentional." >&2
+    fi
+    ;;
+
+esac
+
+# ── final summary ─────────────────────────────────────────────────────────────
 
 if (( ${#missing[@]} > 0 )); then
   echo "Missing required environment variables:" >&2


### PR DESCRIPTION
## Summary

This PR resolves four issues across scripts and documentation.

---

### #479 — `--check` flag for `scripts/generate_abi_metadata.sh`

Added a `--check` flag that generates ABI metadata to a temporary directory and diffs against the committed `abis/*.json` without overwriting them. This matches the convention of tools like `prettier --check` and means CI no longer mutates the working tree before checking it.

- Updated `scripts/generate_abi_metadata.sh` to support `--check`
- Updated `.github/workflows/ci-abi-metadata.yml` to use `--check` instead of generating in-place and then running `git diff`

---

### #480 — `--env` mode flag for `scripts/validate_env.sh`

Added a `--env testnet|mainnet|local` flag with mode-specific required variable lists so the script can catch a mainnet deploy using testnet-only config.

- `local` — warns if `SOROBAN_RPC_URL` does not point to a local node
- `testnet` — requires `STELLAR_NETWORK=testnet` and deployed contract IDs
- `mainnet` — enforces the correct Stellar mainnet network passphrase, rejects testnet RPC URLs, requires all deployed contract IDs and `USDC_CONTRACT_ID`, and requires `STELLAR_NETWORK=mainnet`
- `scripts/deploy_mainnet.sh` updated to call `validate_env.sh` with `--env mainnet`

---

### #481 — `--rollback` mode for `scripts/deploy_mainnet.sh`

Added a `--rollback` mode that restores `artifacts/addresses.json` from its backup (`artifacts/addresses.json.bak`), saves a timestamped forensic copy of the failed state, and prints a detailed explanation of on-chain implications (contracts cannot be un-deployed; this only restores the local address registry).

- Updated `scripts/deploy_mainnet.sh` with `--rollback` mode
- Documented the scripted and manual rollback procedures in `docs/MAINNET_DEPLOYMENT.md` (expanded the Emergency Rollback section)

---

### #478 — `is_allowed` edge-case examples in `docs/contract-interaction-guide.md`

Added three worked `soroban-cli` examples covering the distinct scenarios that produce `is_allowed == false`, so integrators do not assume they are equivalent:

1. **Never allowed** — address was never passed to `allow_address`
2. **Allowance expired** — allowance window has closed; address needs renewal, not block-lifting
3. **Explicitly blocked** — `block_address` was called; address cannot transact until unblocked

Each example includes the expected return value, the corresponding backend error code, and the suggested HTTP response.

---

## Files changed

| File | Issue |
| ---- | ----- |
| `scripts/generate_abi_metadata.sh` | #479 |
| `.github/workflows/ci-abi-metadata.yml` | #479 |
| `scripts/validate_env.sh` | #480 |
| `scripts/deploy_mainnet.sh` | #480, #481 |
| `docs/MAINNET_DEPLOYMENT.md` | #481 |
| `docs/contract-interaction-guide.md` | #478 |

---

Closes #478
Closes #479
Closes #480
Closes #481