### PR TITLE
fix: remind PR authors to link Closes #[issue_id] in the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 ## Checklist
 
-- [ ] Closes #__
+- [ ] PR description includes: Closes #[issue_id]
 - [ ] Tests added or updated
 - [ ] ABI snapshot updated if contract sources changed (`abis/` and `COMEBACKHERE-contracts/`)
 - [ ] Screenshots attached if UI changed


### PR DESCRIPTION
## Summary

Every Stellar Wave issue's Guidelines section requires that the PR description include `Closes #[issue_id]`. This change makes that reminder explicit in `.github/pull_request_template.md` as a checklist item, so contributors do not have to rely on remembering it from the issue body alone.

## Changes

- Updated the PR template checklist item to read: "PR description includes: Closes #[issue_id]"

Closes #513
Closes #510
Closes #512
Closes #505