### PR TITLE
ci: add concurrency groups to all workflow files

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-abi-metadata.yml
+++ b/.github/workflows/ci-abi-metadata.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   generate-abi-metadata:
     name: generate-and-verify-abi-metadata

--- a/.github/workflows/ci-abi-snapshots.yml
+++ b/.github/workflows/ci-abi-snapshots.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-abi:
     name: check-abi-snapshots

--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: cargo test

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -8,6 +8,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   COVERAGE_THRESHOLD: 70
 

--- a/.github/workflows/ci-error-docs.yml
+++ b/.github/workflows/ci-error-docs.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-error-docs-sync:
     name: check-error-codes-docs-sync

--- a/.github/workflows/ci-post-deploy-verify.yml
+++ b/.github/workflows/ci-post-deploy-verify.yml
@@ -17,6 +17,10 @@ on:
         description: "Deployed compliance contract ID (C…)"
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy-testnet:
     name: deploy (testnet)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -8,6 +8,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds `concurrency` groups to all 9 GitHub Actions workflow files to prevent redundant CI runs when new commits are pushed to the same branch or pull request.

### Changes

Each workflow file now includes:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

This was added to:
- `backend-tests.yml`
- `ci-abi-metadata.yml`
- `ci-abi-snapshots.yml`
- `ci-contracts.yml`
- `ci-coverage.yml`
- `ci-error-docs.yml`
- `ci-post-deploy-verify.yml`
- `ci.yml`
- `lint-docs.yml`

### Why

Without concurrency groups, pushing multiple commits to a branch in quick succession triggers a separate CI run for every push. The `cancel-in-progress: true` setting ensures that only the latest run for a given workflow+ref combination is kept active, saving compute resources and reducing queue time.

Closes #489
Closes #488
Closes #487
Closes #486