### PR TITLE
fix(webhooks): sign and verify HMAC over raw body bytes

### DIFF
--- a/comebackhere-backend/src/services/webhooks.ts
+++ b/comebackhere-backend/src/services/webhooks.ts
@@ -7,10 +7,15 @@
  * `signingSecret` argument when called directly).
  *
  * Consumers verify authenticity by:
- *   1. Reading the raw request body (before JSON.parse).
- *   2. Computing HMAC-SHA256(secret, rawBody).
+ *   1. Reading the raw request body as bytes (before JSON.parse).
+ *   2. Computing HMAC-SHA256(secret, rawBody) over those exact bytes.
  *   3. Comparing the hex digest to the `X-COMEBACKHERE-Signature` header
  *      using a constant-time comparison to prevent timing attacks.
+ *
+ * The signature is computed over the raw body bytes (Buffer/Uint8Array), not a
+ * decoded string. This keeps verification stable when the body contains
+ * non-UTF-8 characters or when a proxy preserves the raw payload without
+ * re-encoding it.
  *
  * Header name: `X-COMEBACKHERE-Signature`
  * Algorithm:   HMAC-SHA256
@@ -35,14 +40,31 @@ export interface WebhookDeliveryResult {
 }
 
 /**
+ * Normalize the raw body into the exact bytes that should be signed.
+ *
+ * HMAC input must be the exact raw bytes of the request body. Passing a
+ * `Buffer` or `Uint8Array` preserves the original bytes verbatim, which keeps
+ * signatures stable even when the body contains non-UTF-8 characters or when a
+ * proxy preserves the raw payload without re-encoding it. Supplying a string
+ * still works for backward compatibility and is encoded to its UTF-8 bytes.
+ */
+function toRawBytes(rawBody: string | Buffer | Uint8Array): Buffer {
+  if (Buffer.isBuffer(rawBody)) return rawBody
+  if (rawBody instanceof Uint8Array) {
+    return Buffer.from(rawBody.buffer, rawBody.byteOffset, rawBody.byteLength)
+  }
+  return Buffer.from(rawBody)
+}
+
+/**
  * Compute an HMAC-SHA256 signature over `rawBody` using `secret`.
  *
  * @param secret  - The per-merchant signing secret (minimum 32 chars recommended).
- * @param rawBody - The exact bytes that will be sent as the request body.
+ * @param rawBody - The exact bytes (or string) that will be sent as the request body.
  * @returns Lowercase hex-encoded HMAC-SHA256 digest.
  */
-export function signPayload(secret: string, rawBody: string): string {
-  return createHmac("sha256", secret).update(rawBody, "utf8").digest("hex")
+export function signPayload(secret: string, rawBody: string | Buffer | Uint8Array): string {
+  return createHmac("sha256", secret).update(toRawBytes(rawBody)).digest("hex")
 }
 
 /**
@@ -51,7 +73,11 @@ export function signPayload(secret: string, rawBody: string): string {
  *
  * @returns `true` if the signature is valid, `false` otherwise.
  */
-export function verifySignature(secret: string, rawBody: string, signature: string): boolean {
+export function verifySignature(
+  secret: string,
+  rawBody: string | Buffer | Uint8Array,
+  signature: string,
+): boolean {
   try {
     const expected = signPayload(secret, rawBody)
     // Both buffers must have the same length for timingSafeEqual

--- a/comebackhere-backend/src/tests/webhooks.test.ts
+++ b/comebackhere-backend/src/tests/webhooks.test.ts
@@ -97,6 +97,35 @@ describe("verifySignature", () => {
     // Truncated hex — different byte length
     expect(verifySignature(TEST_SECRET, body, "abcd")).toBe(false)
   })
+
+  it("signs raw non-UTF-8 bytes without data loss", () => {
+    // Body containing raw bytes that are not valid UTF-8 (e.g. latin-1 payload
+    // passed through by a proxy). Signing the raw bytes must match a signature
+    // produced from the identical byte buffer.
+    const rawBody = Buffer.from([0x7b, 0x22, 0x61, 0x22, 0x3a, 0x22, 0xe9, 0x22, 0x7d])
+    const sig = signPayload(TEST_SECRET, rawBody)
+    expect(verifySignature(TEST_SECRET, rawBody, sig)).toBe(true)
+  })
+
+  it("accepts a Uint8Array body for signing and verification", () => {
+    const bodyBytes = Buffer.from('{"event":"test"}')
+    const asUint8 = new Uint8Array(bodyBytes.buffer, bodyBytes.byteOffset, bodyBytes.byteLength)
+    const sig = signPayload(TEST_SECRET, asUint8)
+    expect(verifySignature(TEST_SECRET, asUint8, sig)).toBe(true)
+  })
+
+  it("buffer signature matches the string signature for the same UTF-8 payload", () => {
+    const body = '{"event":"test"}'
+    const bodyBuf = Buffer.from(body)
+    expect(signPayload(TEST_SECRET, bodyBuf)).toBe(signPayload(TEST_SECRET, body))
+  })
+
+  it("tampered raw bytes fail verification", () => {
+    const original = Buffer.from('{"event":"test"}')
+    const tampered = Buffer.from('{"event":"other"}')
+    const sig = signPayload(TEST_SECRET, original)
+    expect(verifySignature(TEST_SECRET, tampered, sig)).toBe(false)
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes intermittent `X-COMEBACKHERE-Signature` HMAC-SHA256 verification failures that occurred when the raw webhook request body contained non-UTF-8 characters or when the payload was re-encoded by a proxy.

## Root Cause

`signPayload`/`verifySignature` passed the raw body through `.update(rawBody, "utf8")`, forcing UTF-8 string re-encoding. When the body contained non-UTF-8 bytes (e.g. a latin-1 payload forwarded by a proxy), the re-encoding replaced invalid sequences with U+FFFD replacement characters, so the computed signature no longer matched the actual raw bytes delivered over the wire — causing verification to fail intermittently.

## Change

- `signPayload` and `verifySignature` now accept the raw body as a `string`, `Buffer`, or `Uint8Array`.
- The HMAC is computed over the exact raw bytes (`Buffer`) with no lossy re-encoding, so signatures stay stable even for non-UTF-8 payloads or proxy-preserved bodies.
- Existing string callers remain fully backward compatible (strings are still encoded to their UTF-8 bytes).

## Tests

Added tests covering raw non-UTF-8 byte payloads, `Uint8Array` input, buffer/string equivalence for UTF-8 payloads, and tampered raw bytes being rejected.

Closes #568
Closes #566